### PR TITLE
open port 80, set up DNS in route 53

### DIFF
--- a/create-env.sh
+++ b/create-env.sh
@@ -6,12 +6,14 @@ ENV=$1
 SG=${ENV}-sg
 USER_DATA_FILE=user-data.yaml
 PG_PASSWORD=$(pwgen -s 20)
-PORTS="22 80 4567"
+PORTS="22 4567"
 
 aws ec2 create-security-group --group-name "$SG" --description "security group for $ENV" > /dev/null
 for PORT in $PORTS; do
     aws ec2 authorize-security-group-ingress --group-name "$SG" --protocol tcp --port "$PORT" --cidr 80.194.77.64/26
 done
+# allow port 80 from anywhere
+aws ec2 authorize-security-group-ingress --group-name "$SG" --protocol tcp --port 80 --cidr 0.0.0.0/0
 
 USER_DATA=$(sed -e "s/%PGPASSWD%/${PG_PASSWORD}/" ${USER_DATA_FILE} | base64)
 


### PR DESCRIPTION
this opens port 80 to the world, and sets up a route 53 name for the new instance.

to use this, you need to create an aws cli profile for the old account by running:

    aws --profile old-dns configure

