### PR TITLE
simplify finding public IP

### DIFF
--- a/create-env.sh
+++ b/create-env.sh
@@ -52,7 +52,7 @@ until [ $tries -ge 5 ]; do
     PUBLIC_IP=$(aws ec2 describe-instances \
         --instance-ids "${INSTANCE_ID}" \
         --query 'Reservations[0].Instances[0].PublicIpAddress' \
-        | tr -d '"')
+        --output text)
     [ -n "$PUBLIC_IP" ] && break
     tries=$[$tries+1]
 done


### PR DESCRIPTION
You don't need to use `tr` to remove the quote chars, you can just use
`--output text` to tell aws cli not to print them in the first place.