### PR TITLE
Clean up create-env script

### DIFF
--- a/create-env.sh
+++ b/create-env.sh
@@ -84,7 +84,7 @@ INSTANCE_ID=$(aws ec2 run-instances \
     --iam-instance-profile Arn=${INSTANCE_PROFILE_ARN} \
     --security-groups "$SG" \
     --query 'Instances[0].InstanceId' \
-    | tr -d '"')
+    --output text)
 
 # the instance won't immediately exist; this retry loop keeps trying
 # until we get the public ip or we've tried 5 times.

--- a/create-env.sh
+++ b/create-env.sh
@@ -2,6 +2,18 @@
 
 set -eu
 
+usage() {
+    echo "Usage: $0 environment-name"
+    echo
+    echo "Creates an EC2 instance, security group and route 53 entry for environment-name"
+}
+
+if [ "$#" -ne 1 ]; then
+    echo "Wrong number of arguments"
+    usage; exit
+fi
+
+
 ENV=$1
 SG=${ENV}-sg
 USER_DATA_FILE=user-data.yaml


### PR DESCRIPTION
The create-env script is getting sufficiently complex that I thought it should be split into functions to describe the overall structure of the code.

This also makes the script report usage if it gets the wrong number of arguments.