### PR TITLE
fix bug in the create-env script

### DIFF
--- a/create-env.sh
+++ b/create-env.sh
@@ -49,9 +49,8 @@ set_up_security_group() {
 
 create_instance() {
     ENV=$1
-    ZONE=$2
-    SG=$3
-    USER_DATA=$4
+    SG=$2
+    USER_DATA=$3
 
     IAM_ROLE=CodeDeployerRole
 
@@ -92,8 +91,9 @@ create_instance() {
 
 create_dns_records() {
     DNS_NAME=$1
-    PUBLIC_IP=$2
-    DNS_PROFILES=$3
+    ZONE=$2
+    PUBLIC_IP=$3
+    DNS_PROFILES=$4
     TTL=300
 
     DNS_CHANGES=$(cat <<EOF


### PR DESCRIPTION
when I pulled all the functions out, I knew I needed to add $ZONE as the
second parameter to a function, but I added it to the wrong function.
This broke creating instances -- and even if instance creation was
fixed, broke DNS record creation.