### PR TITLE
Script code deploy steps

### DIFF
--- a/create-code-deploy-application.sh
+++ b/create-code-deploy-application.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+APPLICATION_NAME=$1
+DEPLOYMENT_GROUP_NAME=$2
+INSTANCE_PROFILE_NAME=$3
+INSTANCE_NAMES=$4
+BUCKET_NAME=$5
+
+
+fetchInstanceProfile(){
+    CODE_DEPLOYER_PROFILE_ARN=$(aws iam get-instance-profile \
+                                --instance-profile-name $INSTANCE_PROFILE_NAME \
+                                --query InstanceProfile.Roles[0].Arn \
+                                --output text)
+
+    echo "$CODE_DEPLOYER_PROFILE_ARN"
+}
+
+
+createApplication(){
+    APPLICATION_ID=$(aws deploy create-application \
+                        --application-name $APPLICATION_NAME \
+                        --output text)
+
+    echo "$APPLICATION_ID"
+}
+
+createDeploymentGroup(){
+    CODE_DEPLOYER_PROFILE_ARN=$1
+    INSTANCE_TAG_FILTERS=""
+    for instance_name in `echo "$INSTANCE_NAMES" | tr "," " "`; do  INSTANCE_TAG_FILTERS="${INSTANCE_TAG_FILTERS} Key=Name,Value=${instance_name},Type=KEY_AND_VALUE"; done
+
+    DEPLOYMENT_GROUP_ID=$(aws deploy create-deployment-group \
+            --application-name $APPLICATION_NAME \
+            --deployment-group-name $DEPLOYMENT_GROUP_NAME \
+            --deployment-config-name CodeDeployDefault.AllAtOnce \
+            --ec2-tag-filters ${INSTANCE_TAG_FILTERS} \
+            --service-role-arn ${CODE_DEPLOYER_PROFILE_ARN} \
+            --output text)
+
+    echo "$DEPLOYMENT_GROUP_ID"
+}
+
+createBucket(){
+    CODE_DEPLOYER_PROFILE_ARN=$1
+
+    aws s3 mb s3://${BUCKET_NAME} --region=eu-west-1
+}
+
+
+usage() {
+    echo "Usage: ./setup-code-deploy-application.sh $1 application-name $2 deployment-group-name $3 instance-propfile-name $4 comma-separated-instance-names $5 s3-bucket-name"
+    echo
+    echo "Creates an application with deployment group at code-deploy"
+}
+
+if [ "$#" -ne 5 ]; then
+    echo "Wrong number of arguments"
+    usage; exit
+fi
+
+runScript(){
+    CODE_DEPLOYER_PROFILE_ARN=$(fetchInstanceProfile)
+    echo "Retreived instance profile arn $CODE_DEPLOYER_PROFILE_ARN"
+
+    APPLICATION_ID=$(createApplication)
+    echo "Created application with id $APPLICATION_ID"
+
+    DEPLOYMENT_GROUP_ID=$(createDeploymentGroup "$CODE_DEPLOYER_PROFILE_ARN")
+    echo "Created Deployment group with id $DEPLOYMENT_GROUP_ID"
+
+    createBucket "$CODE_DEPLOYER_PROFILE_ARN"
+}
+
+deleteAllResources(){
+    echo "Cleaning up all resources"
+
+    echo "Deleting application $APPLICATION_NAME"
+    aws deploy delete-application --application-name $APPLICATION_NAME
+    aws s3 rb s3://$BUCKET_NAME --force
+}
+
+runScript
+#deleteAllResources

--- a/create-code-deployer-instance-profile.sh
+++ b/create-code-deployer-instance-profile.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+
+
+
+usage() {
+    echo "Usage: ./create-code-deployer-instance-profile.sh $1 role-name"
+    echo
+    echo "Creates an instance-profile with role and its permission for code deploy"
+}
+
+if [ "$#" -ne 1 ]; then
+    echo "Wrong number of arguments"
+    usage; exit
+fi
+
+ROLE_NAME=$1
+INSTANCE_PROFILE_NAME=$1
+AWS_CODE_DEPLOY_ROLE_POLICY_ARN="arn:aws:iam::aws:policy/service-role/AWSCodeDeployRole"
+
+runScript(){
+    echo "Creating role $ROLE_NAME"
+    aws iam create-role --role "${ROLE_NAME}" --assume-role-policy-document "{
+      \"Version\": \"2012-10-17\",
+      \"Statement\": [
+        {
+          \"Effect\": \"Allow\",
+          \"Principal\": {
+            \"Service\": [
+              \"codedeploy.eu-west-1.amazonaws.com\"
+            ]
+          },
+          \"Action\": \"sts:AssumeRole\"
+        }
+      ]
+    }"
+
+    echo "Attaching policy $AWS_CODE_DEPLOY_ROLE_POLICY_ARN to $ROLE_NAME"
+    aws iam attach-role-policy \
+    --role-name "${ROLE_NAME}" \
+    --policy-arn "${AWS_CODE_DEPLOY_ROLE_POLICY_ARN}"
+
+
+    echo "putting policy CodeDeployAgentPolicy to $ROLE_NAME"
+    aws iam put-role-policy \
+    --role-name "${ROLE_NAME}" \
+    --policy-name "CodeDeployAgentPolicy" \
+    --policy-document "{
+        \"Version\": \"2012-10-17\",
+        \"Statement\": [
+            {
+                \"Action\": [
+                    \"s3:Get*\",
+                    \"s3:List*\"
+                ],
+                \"Effect\": \"Allow\",
+                \"Resource\": \"arn:aws:s3:::aws-codedeploy-eu-west-1/*\"
+            }
+        ]
+    }"
+
+    echo "putting policy DeployableArtifactBucketsPolicy to $ROLE_NAME"
+    aws iam put-role-policy \
+    --role-name "${ROLE_NAME}" \
+    --policy-name "DeployableArtifactBucketsPolicy" \
+    --policy-document "{
+        \"Version\": \"2012-10-17\",
+        \"Statement\": [
+            {
+                \"Action\": [
+                    \"s3:*\"
+                ],
+                \"Effect\": \"Allow\",
+                \"Resource\": [
+                    \"arn:aws:s3:::presentation.app.artifacts/*\",
+                    \"arn:aws:s3:::mint.app.artifacts/*\"
+                ]
+            }
+        ]
+    }"
+
+    echo "Create instance profile with name INSTANCE_PROFILE_NAME"
+    aws iam create-instance-profile --instance-profile-name "${INSTANCE_PROFILE_NAME}"
+
+    echo "adding role to instance profile"
+    aws iam add-role-to-instance-profile --instance-profile-name "${INSTANCE_PROFILE_NAME}" --role-name "${ROLE_NAME}"
+
+}
+
+deleteAllResources(){
+    echo "Cleaning up all resources"
+    echo "Deleting role policy CodeDeployAgentPolicy"
+    aws iam delete-role-policy --role-name "${ROLE_NAME}" --policy-name "CodeDeployAgentPolicy"
+
+    echo "Deleting role policy DeployableArtifactBucketsPolicy"
+    aws iam delete-role-policy --role-name "${ROLE_NAME}" --policy-name "DeployableArtifactBucketsPolicy"
+
+    echo "Detaching policy arn:aws:iam::aws:policy/service-role/AWSCodeDeployRole"
+    aws iam detach-role-policy --role-name "${ROLE_NAME}" --policy-arn "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRole"
+
+    echo "Deleting role from instance profile"
+    aws iam remove-role-from-instance-profile --instance-profile-name "${ROLE_NAME}" --role-name "${ROLE_NAME}"
+
+    echo "Deleting instance profile ${INSTANCE_PROFILE_NAME}"
+    aws iam delete-instance-profile --instance-profile-name "${INSTANCE_PROFILE_NAME}"
+
+    echo "Deleting Role ${ROLE_NAME}"
+    aws iam delete-role --role-name "${ROLE_NAME}"
+}
+
+runScript
+#deleteAllResources

--- a/create-code-deployer-user-for-travis.sh
+++ b/create-code-deployer-user-for-travis.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+
+usage() {
+    echo "Usage: ./create-code-deployer-user-for-travis.sh $1 user-name"
+    echo
+    echo "Creates an user with required permission to deploy code by travis"
+}
+
+if [ "$#" -ne 1 ]; then
+    echo "Wrong number of arguments"
+    usage; exit
+fi
+
+
+USER_NAME=$1
+AWS_CODE_DEPLOY_FULLACCESS_POLICY_ARN="arn:aws:iam::aws:policy/AWSCodeDeployFullAccess"
+
+runScript(){
+    echo "Creating user $USER_NAME"
+    aws iam create-user --user-name $USER_NAME
+
+    echo "Attaching user policy $AWS_CODE_DEPLOY_FULLACCESS_POLICY_ARN to user $USER_NAME"
+    aws iam attach-user-policy --user-name $USER_NAME --policy-arn $AWS_CODE_DEPLOY_FULLACCESS_POLICY_ARN
+
+    echo "Putting user policy to allow travis to access buckets"
+    aws iam put-user-policy  \
+    --user-name $USER_NAME  \
+    --policy-name "S3_Bucket_Policy_For_Travis"  \
+    --policy-document "{
+        \"Version\": \"2012-10-17\",
+        \"Statement\": [
+            {
+                \"Sid\": \"Stmt1438793257000\",
+                \"Effect\": \"Allow\",
+                \"Action\": [
+                    \"s3:Put*\",
+                    \"s3:Get*\",
+                    \"s3:List*\"
+                ],
+                \"Resource\": [
+                    \"arn:aws:s3:::presentation.app.artifacts/*\",
+                    \"arn:aws:s3:::mint.app.artifacts/*\"
+                ]
+            }
+        ]
+    }"
+}
+
+deleteAllResources(){
+    echo "Cleaning up all resources"
+
+    echo "Detaching user policy $AWS_CODE_DEPLOY_FULLACCESS_POLICY_ARN from user $USER_NAME"
+    aws iam detach-user-policy --user-name $USER_NAME --policy-arn $AWS_CODE_DEPLOY_FULLACCESS_POLICY_ARN
+
+    echo "Deleting user policy S3_Bucket_Policy_For_Travis from user $USER_NAME"
+    aws iam delete-user-policy --user-name $USER_NAME --policy-name "S3_Bucket_Policy_For_Travis"
+
+    echo "Deleting user $USER_NAME"
+    aws iam delete-user --user-name $USER_NAME
+}
+
+runScript
+#deleteAllResources

--- a/deploy-application.sh
+++ b/deploy-application.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+APPLICATION_NAME=$1
+DEPLOYMENT_GROUP_NAME=$2
+BUCKET_NAME=$3
+BUNDLE_NAME=$4
+
+usage() {
+    echo "This script first runs 'aws deploy push' command which creates the deployable bundle and pushes it to s3 bucket."
+    echo "Deployable bundle zip contains all the files from the current directory so must run this script from the deploy directory."
+    echo "secondly it creates a deployment which fetches bundle from s3 and deploys using the deployment group configuration"
+    echo
+    echo "Usage: ./setup-code-deploy-application.sh $1 application-name $2 deployment-group-name $3 s3-bucket-name $4 bundle-name"
+    echo
+}
+
+if [ "$#" -ne 4 ]; then
+    echo "Wrong number of arguments"
+    usage; exit
+fi
+
+aws deploy push \
+  --application-name $APPLICATION_NAME \
+  --s3-location s3://$BUCKET_NAME/$BUNDLE_NAME.zip \
+  --ignore-hidden-files
+
+
+
+aws deploy create-deployment \
+  --application-name $APPLICATION_NAME \
+  --deployment-config-name CodeDeployDefault.OneAtATime \
+  --deployment-group-name $DEPLOYMENT_GROUP_NAME \
+  --s3-location bucket=$BUCKET_NAME,bundleType=zip,key=$BUNDLE_NAME.zip


### PR DESCRIPTION
Added multiple scripts to document the steps taken to setup code deploy.

* create-code-deploy-user-for-travis.sh creates the user to deploy code from travis.
* create-code-deploy-instance-profile.sh creates the instance profile to attach with instances
* create-code-deploy-application.sh creates the application with deployment group at code deploy
* deploy-application.sh runs the deploy steps to deploy application manually.
