### PR TITLE
Added ec2.amazonaws.com in to instance profile trusted policy

### DIFF
--- a/create-code-deployer-instance-profile.sh
+++ b/create-code-deployer-instance-profile.sh
@@ -26,7 +26,8 @@ runScript(){
           \"Effect\": \"Allow\",
           \"Principal\": {
             \"Service\": [
-              \"codedeploy.eu-west-1.amazonaws.com\"
+              \"codedeploy.eu-west-1.amazonaws.com\",
+              \"ec2.amazonaws.com\"
             ]
           },
           \"Action\": \"sts:AssumeRole\"


### PR DESCRIPTION
I removed 'ec2.amazonaws.com' from CodeDeployerRole trusted policy because I thought that it was added by me for code deploy agent installation purpose. So I removed and ran the code deploy agent installation and it worked which made me commit the changes yesterday.
Now we realise that it is required for to deploy the code as well so reverting the changes. added back 'ec2.amazonaws.com' to the instance profile trusted policy.