### PR TITLE
scripts to create and grant access to RDS

### DIFF
--- a/create-code-deployer-instance-profile.sh
+++ b/create-code-deployer-instance-profile.sh
@@ -79,6 +79,26 @@ runScript(){
         ]
     }"
 
+    echo "putting policy PreviewConfigMintAccess to $ROLE_NAME"
+    aws iam put-role-policy \
+    --role-name "${ROLE_NAME}" \
+    --policy-name "PreviewConfigMintAccess" \
+    --policy-document '{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "s3:GetObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::preview.config/mint/*"
+            ],
+            "Effect": "Allow"
+        }
+    ]
+}
+'
+
     echo "Create instance profile with name INSTANCE_PROFILE_NAME"
     aws iam create-instance-profile --instance-profile-name "${INSTANCE_PROFILE_NAME}"
 
@@ -94,6 +114,9 @@ deleteAllResources(){
 
     echo "Deleting role policy DeployableArtifactBucketsPolicy"
     aws iam delete-role-policy --role-name "${ROLE_NAME}" --policy-name "DeployableArtifactBucketsPolicy"
+
+    echo "Deleting role policy PreviewConfigMintAccess"
+    aws iam delete-role-policy --role-name "${ROLE_NAME}" --policy-name "PreviewConfigMintAccess"
 
     echo "Detaching policy arn:aws:iam::aws:policy/service-role/AWSCodeDeployRole"
     aws iam detach-role-policy --role-name "${ROLE_NAME}" --policy-arn "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRole"

--- a/create-env.sh
+++ b/create-env.sh
@@ -135,7 +135,7 @@ fi
 ENV=$1
 INSTANCE_PROFILE_NAME=$2
 # hardcoded for now
-RDS_ENV=rds-test
+RDS_INSTANCE_NAME=rds-test
 
 SG=${ENV}-sg
 USER_DATA_FILE=user-data.yaml
@@ -146,7 +146,7 @@ ZONE=openregister.org
 DOMAIN=beta.${ZONE}
 DNS_NAME=${ENV}.${DOMAIN}
 DNS_PROFILES="old-dns default"
-DB_SG=${RDS_ENV}-db-sg
+DB_SG=${RDS_INSTANCE_NAME}-db-sg
 
 # ensure aws CLI is set up with needed profiles before continuing
 check_aws_profiles_exist "$DNS_PROFILES"

--- a/create-env.sh
+++ b/create-env.sh
@@ -35,6 +35,7 @@ set_up_security_group() {
     ENV=$2
     RESTRICTED_PORTS=$3
     PUBLIC_PORTS=$4
+    DB_SG=$5
 
     AH=80.194.77.64/26
     ANYWHERE=0.0.0.0/0
@@ -46,6 +47,10 @@ set_up_security_group() {
     for PORT in $PUBLIC_PORTS; do
         allow_access_to_sg_port "$SG" "$PORT" "$ANYWHERE"
     done
+
+    # allow access to RDS instance
+    aws ec2 authorize-security-group-ingress --group-name "$DB_SG" --protocol tcp --port 5432 --source-group "$SG"
+
 }
 
 create_instance() {
@@ -126,8 +131,11 @@ if [ "$#" -ne 2 ]; then
     usage; exit
 fi
 
+
 ENV=$1
 INSTANCE_PROFILE_NAME=$2
+# hardcoded for now
+RDS_ENV=rds-test
 
 SG=${ENV}-sg
 USER_DATA_FILE=user-data.yaml
@@ -138,11 +146,12 @@ ZONE=openregister.org
 DOMAIN=beta.${ZONE}
 DNS_NAME=${ENV}.${DOMAIN}
 DNS_PROFILES="old-dns default"
+DB_SG=${RDS_ENV}-db-sg
 
 # ensure aws CLI is set up with needed profiles before continuing
 check_aws_profiles_exist "$DNS_PROFILES"
 
-set_up_security_group "$SG" "$ENV" "$RESTRICTED_PORTS" "$PUBLIC_PORTS"
+set_up_security_group "$SG" "$ENV" "$RESTRICTED_PORTS" "$PUBLIC_PORTS" "$DB_SG"
 
 USER_DATA=$(sed -e "s/%PGPASSWD%/${PG_PASSWORD}/" "${USER_DATA_FILE}" | base64)
 

--- a/create-mint-rds.sh
+++ b/create-mint-rds.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -eu
+
+ENV=$1
+SIZE_GB=5 # in Gb
+INSTANCE_CLASS=db.t2.micro
+DB_SG=${ENV}-db-sg
+PG_USER=postgres
+PG_PASSWORD=$(pwgen -s 20)
+
+DB_SG_ID=$(aws ec2 create-security-group --group-name "$DB_SG" --description "RDS for $ENV" --query GroupId --output text)
+
+aws rds create-db-instance \
+    --db-instance-identifier "$ENV" \
+    --allocated-storage "$SIZE_GB" \
+    --db-instance-class "$INSTANCE_CLASS" \
+    --no-publicly-accessible \
+    --engine postgres \
+    --engine-version 9.4.1 \
+    --master-username "$PG_USER" \
+    --master-user-password "$PG_PASSWORD" \
+    --vpc-security-group-ids "$DB_SG_ID" \
+    --no-multi-az
+
+echo "instance ${ENV} created. master creds are user:${PG_USER}, password:${PG_PASSWORD}"

--- a/create-mint-rds.sh
+++ b/create-mint-rds.sh
@@ -8,6 +8,8 @@ INSTANCE_CLASS=db.t2.micro
 DB_SG=${ENV}-db-sg
 PG_USER=postgres
 PG_PASSWORD=$(pwgen -s 20)
+REGION=eu-west-1
+ACCOUNT_NUMBER=022990953738
 
 DB_SG_ID=$(aws ec2 create-security-group --group-name "$DB_SG" --description "RDS for $ENV" --query GroupId --output text)
 
@@ -22,5 +24,7 @@ aws rds create-db-instance \
     --master-user-password "$PG_PASSWORD" \
     --vpc-security-group-ids "$DB_SG_ID" \
     --no-multi-az
+
+aws rds add-tags-to-resource --resource-name=arn:aws:rds:${REGION}:${ACCOUNT_NUMBER}:db:${ENV} --tags Key=Environment,Value=preview --region "$REGION"
 
 echo "instance ${ENV} created. master creds are user:${PG_USER}, password:${PG_PASSWORD}"


### PR DESCRIPTION
this adds a new script, `create-mint-rds.sh`, which creates an RDS instance.  It also modifies `create-env.sh` to grant access for the new instance to talk to a particular RDS instance's security group.