### PR TITLE
pre-fetch openjdk docker image

### DIFF
--- a/user-data.yaml
+++ b/user-data.yaml
@@ -84,6 +84,7 @@ write_files:
 runcmd:
   - [ service, docker, start ]
   - [ pip, install, docker-compose ]
+  - [ docker, pull, jstepien/openjdk8 ] # make this available for app deployments
   - [ /usr/local/bin/start-docker ]
   - [ usermod, -aG, docker, philandstuff ]
   - [ usermod, -aG, docker, saqib ]


### PR DESCRIPTION
This pre-fetches the openjdk8 docker image that we use for app
deployments.  If we don't do this, then the first time we deploy an app
to an instance will have to download this image and so will take much
longer than a normal deploy would.