### PR TITLE
Don't use the docker group

### DIFF
--- a/user-data.yaml
+++ b/user-data.yaml
@@ -81,6 +81,4 @@ runcmd:
   - [ pip, install, docker-compose ]
   - [ docker, pull, jstepien/openjdk8 ] # make this available for app deployments
   - [ /usr/local/bin/start-docker ]
-  - [ usermod, -aG, docker, philandstuff ]
-  - [ usermod, -aG, docker, omsharma ]
   - [ /usr/local/bin/setup-cdagent.sh ]


### PR DESCRIPTION
Docker has [a number of privilege escalation issues][1]. This means that
adding a user to the docker group allows them to run arbitrary commands
as root, without the auditing and control that a tool such as `sudo`
enforces.

Given this, we should require use of `sudo` to access docker, rather
than using the `docker` group to control access.

[1]: http://www.projectatomic.io/blog/2015/08/why-we-dont-let-non-root-users-run-docker-in-centos-fedora-or-rhel/