### PR TITLE
use different indexer roles in different envs

### DIFF
--- a/create-indexer-instance-profile.sh
+++ b/create-indexer-instance-profile.sh
@@ -12,8 +12,8 @@ if [ "$#" -ne 1 ]; then
 fi
 
 ENV=$1
-ROLE_NAME=indexer-instance-role
-INSTANCE_PROFILE_NAME=indexer-instance-profile
+ROLE_NAME=$ENV-indexer
+INSTANCE_PROFILE_NAME=$ROLE_NAME
 
 
 CONFIG_BUCKET=openregister.${ENV}.config

--- a/create-indexer-instance.sh
+++ b/create-indexer-instance.sh
@@ -18,7 +18,7 @@ VPC=$1
 
 INSTANCE_NAME=indexer
 
-INSTANCE_PROFILE_NAME=indexer-instance-profile
+INSTANCE_PROFILE_NAME=${VPC}-indexer
 
 SG=${VPC}-${INSTANCE_NAME}-sg
 


### PR DESCRIPTION
Indexer instances need different roles in different environments in
order to get access to different configuration.