### PR TITLE
Attached postgresrdsgroup parameter group to rds db instance.

### DIFF
--- a/create-rds-instance.sh
+++ b/create-rds-instance.sh
@@ -30,6 +30,7 @@ DB_SG_ID=$(aws ec2 create-security-group --group-name "$DB_SG" --vpc-id "$VPC_ID
 
 aws rds create-db-instance \
     --db-instance-identifier "$INSTANCE_NAME" \
+    --db-parameter-group-name "postgresrdsgroup" \
     --allocated-storage "$SIZE_GB" \
     --db-instance-class "$INSTANCE_CLASS" \
     --no-publicly-accessible \


### PR DESCRIPTION
Default group has max connection value as {DBInstanceClassMemory/31457280}. we are using t2.micro instances for our databases where the instance class memory is 1GB so the total connections available are 1GB/31457280 i.e. 34. 34 was very small number of connections because we have number of registers deployed.
This parameter group has max_connections value set as 200 which is the only difference with the default parameter group.