### PR TITLE
Repeatable creation of etcd cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ To deploy an environment:
 ```
 ./create-instance.sh <environment-name>
 ```
+
+## Terraform
+
+See the Terraform subdirectory.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,64 @@
+# Terraform for a CoreOS etcd cluster
+
+This directory contains a [Terraform](https://terraform.io) script to repeatably
+create a [CoreOS](https://coreos.com/) etcd cluster.
+
+It creates a VPC, Subnet, Internet Gateway, Routing Table linking the subnet to the gateway, a Security Group, and 3 EC2 instances in that subnet in an etcd cluster.
+
+## Pre-reqs
+
+* Terraform (brew install terraform)
+* Curl (to get the cluster discovery token)
+* AWS access keys
+
+## Running
+
+Firstly, create a file called terraform.tfvars with your access keys in it. These are used by Terraform when accessing AWS.
+
+```bash
+$ cat terraform.tfvars
+aws_access_key = "<your_aws_access_key_here>"
+aws_secret_key = "<your_aws_secret_key_here>"
+```
+
+If you're creating a new cluster from scratch, you'll need to get a new cluster token.
+
+```bash
+$ ./generate_etcd_cluster_token.sh
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100    58  100    58    0     0     60      0 --:--:-- --:--:-- --:--:--    60
+Next steps: terraform plan
+```
+
+This copies the template file (etcd.yml.template) to etcd.yml.template and inserts the token into the discovery line.
+
+Check the planned changes with
+
+```bash
+$ terraform plan
+Refreshing Terraform state prior to plan...
+
+   <... data snipped for brevity... >
+
+Plan: 9 to add, 0 to change, 0 to destroy.
+```
+
+and then you can make them happen with
+
+```bash
+$ terraform apply
+aws_vpc.coreos-vpc-tf: Creating...
+  cidr_block:                "" => "172.20.0.0/16"
+
+  <... output snipped for brevity ...>
+
+Apply complete! Resources: 9 added, 0 changed, 0 destroyed.
+
+The state of your infrastructure has been saved to the path
+below. This state is required to modify and destroy your
+infrastructure, so keep it safe. To inspect the complete state
+use the `terraform show` command.
+
+State path: terraform.tfstate
+```

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -63,6 +63,50 @@ use the `terraform show` command.
 State path: terraform.tfstate
 ```
 
+## Tear-down
+
+```
+$ terraform destroy
+```
+Do you really want to destroy?
+  Terraform will delete all your managed infrastructure.
+  There is no undo. Only 'yes' will be accepted to confirm.
+
+  Enter a value: yes
+
+aws_vpc.coreos-vpc-tf: Refreshing state... (ID: vpc-965508f3)
+aws_internet_gateway.coreos-vpc-gw-tf: Refreshing state... (ID: igw-3356c856)
+aws_subnet.coreos-subnet-tf: Refreshing state... (ID: subnet-6774303e)
+aws_security_group.coreos-tf: Refreshing state... (ID: sg-d66307b2)
+aws_route_table.coreos-rt-tf: Refreshing state... (ID: rtb-f15c6294)
+aws_route_table_association.coreos-rta-tf: Refreshing state... (ID: rtbassoc-c75b40a2)
+aws_instance.coreos-tf-example.0: Refreshing state... (ID: i-514bd4dc)
+aws_instance.coreos-tf-example.1: Refreshing state... (ID: i-564bd4db)
+aws_instance.coreos-tf-example.2: Refreshing state... (ID: i-c44ad549)
+aws_route_table_association.coreos-rta-tf: Destroying...
+aws_instance.coreos-tf-example.1: Destroying...
+aws_instance.coreos-tf-example.0: Destroying...
+aws_instance.coreos-tf-example.2: Destroying...
+aws_route_table_association.coreos-rta-tf: Destruction complete
+aws_route_table.coreos-rt-tf: Destroying...
+aws_route_table.coreos-rt-tf: Destruction complete
+aws_internet_gateway.coreos-vpc-gw-tf: Destroying...
+aws_internet_gateway.coreos-vpc-gw-tf: Destruction complete
+aws_instance.coreos-tf-example.1: Destruction complete
+aws_instance.coreos-tf-example.2: Destruction complete
+aws_instance.coreos-tf-example.0: Destruction complete
+aws_subnet.coreos-subnet-tf: Destroying...
+aws_security_group.coreos-tf: Destroying...
+aws_security_group.coreos-tf: Destruction complete
+aws_subnet.coreos-subnet-tf: Destruction complete
+aws_vpc.coreos-vpc-tf: Destroying...
+aws_vpc.coreos-vpc-tf: Destruction complete
+
+Apply complete! Resources: 0 added, 0 changed, 9 destroyed.
+```
+
 ## Notes
 
 The state file records all the things that Terraform created and knows about. Terraform [recommend that you place this into source control](https://www.terraform.io/intro/getting-started/build.html) to ensure everyone has the same copy.
+
+Items created outside of Terraform (eg not registed inside the tfstate file) will be ignored.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -108,4 +108,4 @@ Apply complete! Resources: 0 added, 0 changed, 9 destroyed.
 
 The state file records all the things that Terraform created and knows about. Terraform [recommend that you place this into source control](https://www.terraform.io/intro/getting-started/build.html) to ensure everyone has the same copy.
 
-Items created outside of Terraform (eg not registed inside the tfstate file) will be ignored.
+Items created outside of Terraform (eg not registered in the tfstate file) will be ignored.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -67,7 +67,6 @@ State path: terraform.tfstate
 
 ```
 $ terraform destroy
-```
 Do you really want to destroy?
   Terraform will delete all your managed infrastructure.
   There is no undo. Only 'yes' will be accepted to confirm.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -62,3 +62,7 @@ use the `terraform show` command.
 
 State path: terraform.tfstate
 ```
+
+## Notes
+
+The state file records all the things that Terraform created and knows about. Terraform [recommend that you place this into source control](https://www.terraform.io/intro/getting-started/build.html) to ensure everyone has the same copy.

--- a/terraform/coreos.tf
+++ b/terraform/coreos.tf
@@ -1,0 +1,115 @@
+provider "aws" {
+    access_key = "${var.aws_access_key}"
+    secret_key = "${var.aws_secret_key}"
+    region = "eu-west-1"
+}
+
+resource "aws_vpc" "coreos-vpc-tf" {
+    cidr_block = "172.20.0.0/16"
+    enable_dns_support = "true"
+    enable_dns_hostnames = "true"
+
+    tags {
+        Name = "CoreOS VPC (tf)"
+    }
+}
+
+resource "aws_internet_gateway" "coreos-vpc-gw-tf" {
+    vpc_id = "${aws_vpc.coreos-vpc-tf.id}"
+
+    tags {
+        Name = "VPC Gateway (tf)"
+    }
+}
+
+resource "aws_subnet" "coreos-subnet-tf" {
+    vpc_id = "${aws_vpc.coreos-vpc-tf.id}"
+    cidr_block = "172.20.10.0/24"
+    map_public_ip_on_launch = "true"
+    tags {
+        Name = "Test-A (tf)"
+    }
+}
+
+resource "aws_route_table" "coreos-rt-tf" {
+    vpc_id = "${aws_vpc.coreos-vpc-tf.id}"
+
+    route {
+        cidr_block = "0.0.0.0/0"
+        gateway_id = "${aws_internet_gateway.coreos-vpc-gw-tf.id}"
+    }
+
+    tags {
+        Name = "CoreOS route table (tf)"
+    }
+}
+
+resource "aws_route_table_association" "coreos-rta-tf" {
+    subnet_id = "${aws_subnet.coreos-subnet-tf.id}"
+    route_table_id = "${aws_route_table.coreos-rt-tf.id}"
+}
+
+resource "aws_security_group" "coreos-tf" {
+  name = "CoresOS testing security group (TF)"
+  description = "SSH from anywhere, and local ETCD connections"
+  vpc_id = "${aws_vpc.coreos-vpc-tf.id}"
+
+  ingress {
+      from_port = 22
+      to_port = 22
+      protocol = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    cidr_blocks = ["0.0.0.0/0"]
+    protocol = "icmp"
+    from_port = 8
+    to_port = 0
+  }
+
+  ingress {
+      from_port = 2379
+      to_port = 2380
+      protocol = "tcp"
+      self = true
+  }
+
+  ingress {
+      from_port = 4001
+      to_port = 4001
+      protocol = "tcp"
+      self = true
+  }
+
+  ingress {
+      from_port = 7001
+      to_port = 7001
+      protocol = "tcp"
+      self = true
+  }
+
+  egress {
+      from_port = 0
+      to_port = 0
+      protocol = "-1"
+      cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    Name = "CoreOS testing security group (tf)"
+  }
+}
+
+resource "aws_instance" "coreos-tf-example" {
+    count = 3
+    ami = "ami-fd6ccd8e"
+    instance_type = "t1.micro"
+    user_data = "${file("../etcd.yml")}"
+    subnet_id = "${aws_subnet.coreos-subnet-tf.id}"
+    vpc_security_group_ids = [ "${aws_security_group.coreos-tf.id}" ]
+
+    tags {
+      Name = "coreos (instance ${count.index}) (tf)"
+    }
+}

--- a/terraform/etcd.yml.template
+++ b/terraform/etcd.yml.template
@@ -1,0 +1,28 @@
+#cloud-config
+
+coreos:
+  etcd2:
+    # generate a new token for each unique cluster from https://discovery.etcd.io/new?size=3
+    # specify the initial size of your cluster with ?size=X
+    #discovery: https://discovery.etcd.io/<token>
+    # multi-region and multi-cloud deployments need to use $public_ipv4
+    advertise-client-urls: http://$private_ipv4:2379,http://$private_ipv4:4001
+    initial-advertise-peer-urls: http://$private_ipv4:2380
+    # listen on both the official ports and the legacy ports
+    # legacy ports can be omitted if your application doesn't depend on them
+    listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
+    listen-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
+  units:
+    - name: etcd2.service
+      command: start
+    - name: fleet.service
+      command: start
+
+users:
+  - name: andrewg
+    passwd:
+    groups:
+      - sudo
+      - docker
+    ssh-authorized-keys:
+      - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCW+YYupls/+vc2phpLrZkaSOQsDCfss/Uh0RlYBjle4zz5VO4ZbV23CmwnQwtJZumGl6NguCiuHuQw++BaNyuFK/N3mHyM3qr3leMRFBLp5cQl665SydfOdxxMWt2nKmqtoA9algpKNoF5cRBI5mo968/FHhk4zNNa1gplgAEctXvu2xyRxZUkRZCq7ZheamDdw1/vpjG/mLdcSyjlYBy/iG1tgCc2iYcA2ZFLlisY7+cErNUMRcZJ0hEb/Bm0cZSEYaxRy48lhQmfsHCgcLmB6JfJ2s0T+EKOaC1ZE0gBtAjh9Z/UFZB/LJZpxp3Hqa1WdxVOzfbpyN6X5Xx3dEjv andrew.gorton@digital.cabinet-office.gov.uk

--- a/terraform/generate_etcd_cluster_token.sh
+++ b/terraform/generate_etcd_cluster_token.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Set the discovery token
+cp etcd.yml.template etcd.yml
+curl https://discovery.etcd.io/new > discovery.token
+grep "Unable to generate token" discovery.token
+if [ $? != 1 ]; then
+  echo Failed to generate discovery token.
+  exit -1
+fi
+sed -i '' -e "s,#discovery: https://discovery.etcd.io/<token>,discovery: $(sed 's:/:\\/:g' discovery.token),"  etcd.yml
+
+echo "Next steps: terraform plan"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,2 @@
+variable "aws_access_key" {}
+variable "aws_secret_key" {}


### PR DESCRIPTION
Uses Terraform for repeatable provisioning of a CoreOS ETCD cluster.

Terraform also creates the VPC, internet gateway, subnet, associated routing table, security group and EC2 instances.