### PR TITLE
refactor security groups

### DIFF
--- a/aws/modules/database/security_group.tf
+++ b/aws/modules/database/security_group.tf
@@ -8,3 +8,12 @@ resource "aws_security_group" "db" {
     Environment = "${var.vpc_name}"
   }
 }
+
+resource "aws_security_group_rule" "inbound_postgres" {
+  security_group_id = "${aws_security_group.db.id}"
+  type = "ingress"
+  from_port = 5432
+  to_port = 5432
+  protocol = "tcp"
+  cidr_blocks = ["${split(" ", var.allow_from)}"]
+}

--- a/aws/modules/database/variables.tf
+++ b/aws/modules/database/variables.tf
@@ -14,6 +14,8 @@ variable "count" {
 variable "password" {}
 variable "username" {}
 
+variable "allow_from" {}
+
 variable "multi_az" {
   default = "false"
 }

--- a/aws/modules/presentation/security_group.tf
+++ b/aws/modules/presentation/security_group.tf
@@ -55,3 +55,12 @@ resource "aws_security_group_rule" "outbound_https" {
   protocol = "tcp"
   cidr_blocks = ["0.0.0.0/0"]
 }
+
+resource "aws_security_group_rule" "outbound_postgres" {
+  security_group_id = "${aws_security_group.presentation.id}"
+  type = "egress"
+  from_port = 5432
+  to_port = 5432
+  protocol = "tcp"
+  cidr_blocks = ["${split(" ", var.db_cidr_block)}"]
+}

--- a/aws/modules/presentation/variables.tf
+++ b/aws/modules/presentation/variables.tf
@@ -3,6 +3,7 @@ variable "vpc_name" {}
 variable "vpc_id" {}
 
 variable "cidr_block" {}
+variable "db_cidr_block" {}
 
 variable "public_route_table_id" {}
 

--- a/aws/registers/read_api.tf
+++ b/aws/registers/read_api.tf
@@ -6,6 +6,9 @@ module "presentation" {
   vpc_id = "${module.core.vpc_id}"
 
   cidr_block = "${var.read_api_cidr_block}"
+
+  db_cidr_block = "${var.read_api_database_cidr_block}"
+
   nat_gateway_id = "${module.core.nat_gateway_id}"
   nat_private_ip = "${module.core.nat_private_ip}"
   public_route_table_id = "${module.core.public_route_table_id}"
@@ -20,24 +23,8 @@ module "presentation_db" {
 
   cidr_block = "${var.read_api_database_cidr_block}"
 
+  allow_from = "${var.read_api_cidr_block}"
+
   username = "${var.read_api_rds_username}"
   password = "${var.read_api_rds_password}"
-}
-
-resource "aws_security_group_rule" "outbound_postgres" {
-  security_group_id = "${module.presentation.security_group_id}"
-  type = "egress"
-  from_port = 5432
-  to_port = 5432
-  protocol = "tcp"
-  source_security_group_id = "${module.presentation_db.security_group_id}"
-}
-
-resource "aws_security_group_rule" "inbound_presentation" {
-  security_group_id = "${module.presentation_db.security_group_id}"
-  type = "ingress"
-  from_port = 5432
-  to_port = 5432
-  protocol = "tcp"
-  source_security_group_id = "${module.presentation.security_group_id}"
 }

--- a/aws/registers/write_api.tf
+++ b/aws/registers/write_api.tf
@@ -23,6 +23,8 @@ module "mint_db" {
 
   cidr_block = "${var.write_api_database_cidr_block}"
 
+  allow_from = "${var.write_api_mint_cidr_block}"
+
   username = "${var.read_api_rds_username}"
   password = "${var.read_api_rds_password}"
 }
@@ -35,6 +37,9 @@ module "mint" {
   vpc_id = "${module.core.vpc_id}"
 
   cidr_block = "${var.write_api_mint_cidr_block}"
+
+  // not implemented yet, but we'll need it for mint to access RDS
+  // db_cidr_block = "${var.write_api_database_cidr_block}"
 
   nat_gateway_id = "${module.core.nat_gateway_id}"
   nat_private_ip = "${module.core.nat_private_ip}"


### PR DESCRIPTION
This defines the security groups in terms of source CIDR blocks rather
than source security groups, and pushes the rule resources down into the
modules.