### PR TITLE
Add config and IAM access to allow Mint to heartbeat to CloudWatch.

### DIFF
--- a/ansible/roles/service_config/templates/mint-config.yaml.j2
+++ b/ansible/roles/service_config/templates/mint-config.yaml.j2
@@ -22,3 +22,6 @@ register: {{ register_name }}
 credentials:
   user: {{ app_user }}
   password: {{ app_password }}
+
+  # If set, heartbeat to CloudWatch under this namespace
+  cloudWatchEnvironmentName: {{ vpc }}

--- a/aws/modules/instance_policy/iam_policy_cloudwatch_access.tf
+++ b/aws/modules/instance_policy/iam_policy_cloudwatch_access.tf
@@ -1,0 +1,21 @@
+resource "aws_iam_role_policy" "iam_policy_cloudwatch_access" {
+  name = "${format("%s_CloudWatch_PutMetricData", var.vpc_name)}"
+  role = "${aws_iam_role.instance_policy.id}"
+  policy = <<POLICY
+  {
+      "Version": "2012-10-17",
+      "Statement": [
+          {
+              "Sid": "Stmt1456223097000",
+              "Effect": "Allow",
+              "Action": [
+                  "cloudwatch:PutMetricData"
+              ],
+              "Resource": [
+                  "*"
+              ]
+          }
+      ]
+  }
+POLICY
+}

--- a/aws/modules/mint/iam_policy_cloudwatch_access.tf
+++ b/aws/modules/mint/iam_policy_cloudwatch_access.tf
@@ -1,0 +1,21 @@
+resource "aws_iam_role_policy" "iam_policy_cloudwatch_access" {
+  name = "${format("%s_CloudWatch_PutMetricData", var.vpc_name)}"
+  role = "${aws_iam_role.mint_role.id}"
+  policy = <<POLICY
+  {
+      "Version": "2012-10-17",
+      "Statement": [
+          {
+              "Sid": "Stmt1456223097000",
+              "Effect": "Allow",
+              "Action": [
+                  "cloudwatch:PutMetricData"
+              ],
+              "Resource": [
+                  "*"
+              ]
+          }
+      ]
+  }
+POLICY
+}

--- a/create-appserver-managed-policy.sh
+++ b/create-appserver-managed-policy.sh
@@ -24,6 +24,16 @@ aws iam create-policy --policy-name 'RegisterAppServer' --policy-document '{
                 "ec2:DescribeTags"
             ],
             "Resource": ["*"]
+        },
+        {
+            "Sid": "Stmt1456223097000",
+            "Effect": "Allow",
+            "Action": [
+                "cloudwatch:PutMetricData"
+            ],
+            "Resource": [
+                "*"
+            ]
         }
     ]
 }


### PR DESCRIPTION
This needs merging after https://github.com/openregister/mint/pull/65, otherwise Mint will complain of an unknown configuration directive.

The code which reads the configuration is safe - if the config isn't set, then heartbeating is not enabled.