### PR TITLE
Tf env dedicated zones in route53

### DIFF
--- a/aws/modules/core/outputs.tf
+++ b/aws/modules/core/outputs.tf
@@ -53,3 +53,10 @@ output "public_route_table_id" {
 output "public_subnet_ids" {
   value = "${join(" ", aws_subnet.public.*.id)}"
 }
+
+/*
+ * route53.tf exports
+*/
+output "dns_zone_id" {
+  value = "${aws_route53_zone.core.zone_id}"
+}

--- a/aws/modules/core/route53.tf
+++ b/aws/modules/core/route53.tf
@@ -10,7 +10,7 @@ resource "aws_route53_record" "natgw" {
   records = [ "${aws_instance.natgw.public_ip}" ]
 }
 
-resource "aws_route53_record" "nameservers" {
+resource "aws_route53_record" "zone_delegation" {
   zone_id = "${var.dns_parent_zone_id}"
   name = "${var.vpc_name}.${var.dns_domain}"
   type = "NS"

--- a/aws/modules/core/route53.tf
+++ b/aws/modules/core/route53.tf
@@ -1,7 +1,19 @@
+resource "aws_route53_zone" "core" {
+  name = "${var.vpc_name}.${var.dns_domain}"
+}
+
 resource "aws_route53_record" "natgw" {
-  zone_id = "${var.dns_zone_id}"
+  zone_id = "${aws_route53_zone.core.zone_id}"
   name = "gateway.${var.vpc_name}.${var.dns_domain}"
   type = "A"
   ttl = "${var.dns_ttl}"
   records = [ "${aws_instance.natgw.public_ip}" ]
+}
+
+resource "aws_route53_record" "nameservers" {
+  zone_id = "${var.dns_parent_zone_id}"
+  name = "${var.vpc_name}.${var.dns_domain}"
+  type = "NS"
+  ttl = "${var.dns_ttl}"
+  records = [ "${aws_route53_zone.core.name_servers}" ]
 }

--- a/aws/modules/core/variables.tf
+++ b/aws/modules/core/variables.tf
@@ -31,14 +31,14 @@ variable "admin_ips" {}
  * route53.tf
 */
 
-variable "dns_zone_id" {
-  default = "Z1QBBZW8ZAZIDC"
-}
-
 variable "dns_ttl" {
   default = "300"
 }
 
 variable "dns_domain" {
   default = "openregister.org"
+}
+
+variable "dns_parent_zone_id" {
+  default = "Z1QBBZW8ZAZIDC"
 }

--- a/aws/modules/load_balancer/variables.tf
+++ b/aws/modules/load_balancer/variables.tf
@@ -14,9 +14,7 @@ variable "security_group_ids" {}
  * route53.tf
 */
 
-variable "dns_zone_id" {
-  default = "Z1QBBZW8ZAZIDC"
-}
+variable "dns_zone_id" {}
 
 variable "dns_ttl" {
   default = "300"

--- a/aws/modules/register/variables.tf
+++ b/aws/modules/register/variables.tf
@@ -2,6 +2,8 @@ variable "id" {}
 variable "vpc_id" {}
 variable "vpc_name" {}
 
+variable "config_bucket" {}
+
 variable "instance_ami" {
   default = "ami-a10897d6"
 }
@@ -41,9 +43,7 @@ variable "elb_subnet_ids" {}
  *  dns.tf
  */
 
-variable "dns_zone_id" {
-  default = "Z1QBBZW8ZAZIDC"
-}
+variable "dns_zone_id" {}
 
 variable "dns_ttl" {
   default = "300"
@@ -52,7 +52,3 @@ variable "dns_ttl" {
 variable "dns_domain" {
   default = "openregister.org"
 }
-
-variable "config_bucket" {}
-
-//variable "rds_instance" {}

--- a/aws/registers/register_country.tf
+++ b/aws/registers/register_country.tf
@@ -42,6 +42,9 @@ module "country_elb" {
   instance_ids = "${module.country_presentation.instance_ids}"
   security_group_ids = "${module.presentation.security_group_id}"
   subnet_ids = "${module.core.public_subnet_ids}"
+
+  dns_zone_id = "${module.core.dns_zone_id}"
+
 }
 
 module "country_policy" {

--- a/aws/registers/register_datatype.tf
+++ b/aws/registers/register_datatype.tf
@@ -42,6 +42,8 @@ module "datatype_elb" {
   instance_ids = "${module.datatype_presentation.instance_ids}"
   security_group_ids = "${module.presentation.security_group_id}"
   subnet_ids = "${module.core.public_subnet_ids}"
+
+  dns_zone_id = "${module.core.dns_zone_id}"
 }
 
 module "datatype_policy" {

--- a/aws/registers/register_field.tf
+++ b/aws/registers/register_field.tf
@@ -42,6 +42,8 @@ module "field_elb" {
   instance_ids = "${module.field_presentation.instance_ids}"
   security_group_ids = "${module.presentation.security_group_id}"
   subnet_ids = "${module.core.public_subnet_ids}"
+
+  dns_zone_id = "${module.core.dns_zone_id}"
 }
 
 module "field_policy" {

--- a/aws/registers/register_public_body.tf
+++ b/aws/registers/register_public_body.tf
@@ -42,6 +42,8 @@ module "public-body_elb" {
   instance_ids = "${module.public-body_presentation.instance_ids}"
   security_group_ids = "${module.presentation.security_group_id}"
   subnet_ids = "${module.core.public_subnet_ids}"
+
+  dns_zone_id = "${module.core.dns_zone_id}"
 }
 
 module "public-body_policy" {

--- a/aws/registers/register_register.tf
+++ b/aws/registers/register_register.tf
@@ -42,6 +42,8 @@ module "register_elb" {
   instance_ids = "${module.register_presentation.instance_ids}"
   security_group_ids = "${module.presentation.security_group_id}"
   subnet_ids = "${module.core.public_subnet_ids}"
+
+  dns_zone_id = "${module.core.dns_zone_id}"
 }
 
 module "register_policy" {


### PR DESCRIPTION
This merge introduces an environment-specific Route53 zones.

The intention is to reduce bloat effect on the main zone and provide better configuration clarity.

The core module will link environment's zone with master zone via dns_parent_zone_id variable. 

A disadvantage to this approach is an extra cost - as Amazon is charging $0.50 per hosted zone / month.

 








