### PR TITLE
Ansible mint dataloader refactor

### DIFF
--- a/ansible/mint_address_data.yml
+++ b/ansible/mint_address_data.yml
@@ -1,0 +1,30 @@
+---
+- name: Load street-classification data
+  hosts:
+    - '&tag_Environment_{{ vpc | normalize_ec2_tags }}'
+    - '&tag_Role_mint_app'
+    - '&tag_Register_street_classification'
+  tags:
+    - street-classification
+    - street_classification
+
+  roles:
+    - { role: service_data,
+      id: 'street-classification',
+      src_data: '../../address-data/data/street-classification',
+    }
+
+- name: Load street-surface data
+  hosts:
+    - '&tag_Environment_{{ vpc | normalize_ec2_tags }}'
+    - '&tag_Role_mint_app'
+    - '&tag_Register_street_surface'
+  tags:
+    - street-surface
+    - street_surface
+
+  roles:
+    - { role: service_data,
+      id: 'street-surface',
+      src_data: '../../address-data/data/street-surface',
+    }

--- a/ansible/mint_core_data.yml
+++ b/ansible/mint_core_data.yml
@@ -47,7 +47,9 @@
     - '&tag_Environment_{{ vpc | normalize_ec2_tags }}'
     - '&tag_Role_mint_app'
     - '&tag_Register_public_body'
-  tags: public_body
+  tags:
+    - public_body
+    - public-body
 
   roles:
     - { role: service_data,

--- a/ansible/mint_core_data.yml
+++ b/ansible/mint_core_data.yml
@@ -52,18 +52,3 @@
       file: 'public-body.tsv',
       file_type: 'tsv',
     }
-
-- name: Load country data
-  hosts:
-    - '&tag_Environment_{{ vpc | normalize_ec2_tags }}'
-    - '&tag_Role_mint_app'
-    - '&tag_Register_country'
-  tags: country
-
-  roles:
-    - { role: service_data,
-      id: 'country',
-      src_data: '../../country-data/data/country/countries.tsv',
-      file: 'countries.tsv',
-      file_type: 'tsv',
-    }

--- a/ansible/mint_core_data.yml
+++ b/ansible/mint_core_data.yml
@@ -1,5 +1,6 @@
 ---
 - name: Load datatype data
+  gather_facts: false
   hosts:
     - '&tag_Environment_{{ vpc | normalize_ec2_tags }}'
     - '&tag_Role_mint_app'
@@ -13,6 +14,7 @@
     }
 
 - name: Load field data
+  gather_facts: false
   hosts:
     - '&tag_Environment_{{ vpc | normalize_ec2_tags }}'
     - '&tag_Role_mint_app'
@@ -26,6 +28,7 @@
     }
 
 - name: Load register data
+  gather_facts: false
   hosts:
     - '&tag_Environment_{{ vpc | normalize_ec2_tags }}'
     - '&tag_Role_mint_app'
@@ -39,6 +42,7 @@
     }
 
 - name: Public body data
+  gather_facts: false
   hosts:
     - '&tag_Environment_{{ vpc | normalize_ec2_tags }}'
     - '&tag_Role_mint_app'

--- a/ansible/mint_country_data.yml
+++ b/ansible/mint_country_data.yml
@@ -1,0 +1,15 @@
+---
+- name: Load country data
+  hosts:
+    - '&tag_Environment_{{ vpc | normalize_ec2_tags }}'
+    - '&tag_Role_mint_app'
+    - '&tag_Register_country'
+  tags: country
+
+  roles:
+    - { role: service_data,
+      id: 'country',
+      src_data: '../../country-data/data/country/countries.tsv',
+      file: 'countries.tsv',
+      file_type: 'tsv',
+    }

--- a/ansible/roles/service_data/tasks/data.yml
+++ b/ansible/roles/service_data/tasks/data.yml
@@ -1,0 +1,6 @@
+- name: Ensure target directory exists
+  file: state=directory dest="{{ workdir }}"
+
+- name: Upload data files
+  synchronize: src="{{ src_data }}" dest="{{ workdir }}/"
+  delegate_to: 127.0.0.1

--- a/ansible/roles/service_data/tasks/docker.yml
+++ b/ansible/roles/service_data/tasks/docker.yml
@@ -1,0 +1,29 @@
+- name: docker service is running
+  service: name=docker state=running
+
+- name: Configure docker instance
+  become: yes
+  vars:
+    datasource: "{{ workdir }}/{{ file | default(id) }}"
+    type: "{{ file_type | default('yaml_dir') }}"
+    mint_password: "{{ lookup('pass', '{{ vpc }}/app/mint/{{ id }}') }}"
+
+  docker:
+    state: 'started'
+    name: 'dataloader-{{ id }}'
+    image: 'jstepien/openjdk8'
+
+    env:
+      MINT_PASSWORD: "{{ lookup('pass', '{{ vpc }}/app/mint/{{ id }}') }}"
+
+    command: >
+      /opt/openjdk8/bin/java -jar /srv/loader.jar
+      --type={{ type }}
+      --datasource={{ datasource }}
+      --minturl=http://{{ mint_user }}:{{ mint_password }}@{{ mint_url }}
+
+    links: mintApp
+
+    volumes:
+      - '/srv/loader.jar:/srv/loader.jar:ro'
+      - '{{ datasource }}:{{ datasource }}:ro'

--- a/ansible/roles/service_data/tasks/docker.yml
+++ b/ansible/roles/service_data/tasks/docker.yml
@@ -13,9 +13,6 @@
     name: 'dataloader-{{ id }}'
     image: 'jstepien/openjdk8'
 
-    env:
-      MINT_PASSWORD: "{{ lookup('pass', '{{ vpc }}/app/mint/{{ id }}') }}"
-
     command: >
       /opt/openjdk8/bin/java -jar /srv/loader.jar
       --type={{ type }}

--- a/ansible/roles/service_data/tasks/main.yml
+++ b/ansible/roles/service_data/tasks/main.yml
@@ -1,27 +1,4 @@
-- name: Deploy data loader
-  copy: src="{{ loader_jar | expanduser }}" dest="/srv/loader.jar"
-  become: yes
-
-- name: Upload data files
-  synchronize: src="{{ src_data }}" dest="{{ workdir }}/"
-
-- name: Configure docker instance
-  docker:
-    state: started
-    name: 'dataloader-{{ id }}'
-    image: 'jstepien/openjdk8'
-
-    env:
-      datasource: "{{ file | default(id) }}"
-      type: "{{ file_type | default('yaml_dir') }}"
-      mint_password: "{{ lookup('pass', '{{ vpc }}/app/mint/{{ id }}') }}"
-
-    command: >
-      '/usr/bin/java8 -jar /srv/loader.jar'
-      '--type={{ type }}'
-      '--datasource={{ datasource }}'
-      '--minturl=http://{{ mint_user }}:{{ mint_password }}@{{ mint_url }}'
-
-    volumes:
-      - '/srv/loader.jar'
-      - '{{ workdir }}/{{ id }}'
+---
+- include: packages.yml
+- include: data.yml
+- include: docker.yml

--- a/ansible/roles/service_data/tasks/main.yml
+++ b/ansible/roles/service_data/tasks/main.yml
@@ -1,22 +1,27 @@
-- name: Ensure JRE v1.8 is installed
-  yum: state=present name="java-1.8.0-openjdk.x86_64"
+- name: Deploy data loader
+  copy: src="{{ loader_jar | expanduser }}" dest="/srv/loader.jar"
   become: yes
 
 - name: Upload data files
   synchronize: src="{{ src_data }}" dest="{{ workdir }}/"
 
-- name: Upload loader
-  copy: src="{{ loader_jar | expanduser }}" dest="/srv/loader.jar"
-  become: yes
+- name: Configure docker instance
+  docker:
+    state: started
+    name: 'dataloader-{{ id }}'
+    image: 'jstepien/openjdk8'
 
-- name: Load data
-  become: yes
-  environment:
-     PASSWORD_STORE_DIR: "{{ pass_store_location | expanduser }}"
-  vars:
-    datasource: "{{ file | default(id) }}"
-    type: "{{ file_type | default('yaml_dir') }}"
-    mint_password: "{{ lookup('pass', '{{ vpc }}/app/mint/{{ id }}') }}"
-  command: "/usr/bin/java8 -jar /srv/loader.jar --minturl=http://{{ mint_user }}:{{ mint_password }}@{{ mint_url }} --datasource={{ datasource }} --type={{ type }}"
-  args:
-    chdir: '{{ workdir }}'
+    env:
+      datasource: "{{ file | default(id) }}"
+      type: "{{ file_type | default('yaml_dir') }}"
+      mint_password: "{{ lookup('pass', '{{ vpc }}/app/mint/{{ id }}') }}"
+
+    command: >
+      '/usr/bin/java8 -jar /srv/loader.jar'
+      '--type={{ type }}'
+      '--datasource={{ datasource }}'
+      '--minturl=http://{{ mint_user }}:{{ mint_password }}@{{ mint_url }}'
+
+    volumes:
+      - '/srv/loader.jar'
+      - '{{ workdir }}/{{ id }}'

--- a/ansible/roles/service_data/tasks/packages.yml
+++ b/ansible/roles/service_data/tasks/packages.yml
@@ -1,0 +1,7 @@
+- name: Ensure docker-py is installed
+  pip: state=present name=docker-py
+  become: yes
+
+- name: Deploy data loader
+  copy: src="{{ loader_jar | expanduser }}" dest="/srv/loader.jar"
+  become: yes

--- a/ansible/roles/service_data/vars/main.yml
+++ b/ansible/roles/service_data/vars/main.yml
@@ -1,4 +1,4 @@
-workdir: '/tmp/mint-uploads'
+workdir: '/srv/mint-data'
 
 mint_user: 'openregister'
 mint_url: 'localhost:4567/load'

--- a/ansible/roles/service_data/vars/main.yml
+++ b/ansible/roles/service_data/vars/main.yml
@@ -1,7 +1,7 @@
-workdir: '/srv/mint-data'
+workdir: '/tmp/mint-data'
 
 mint_user: 'openregister'
-mint_url: 'localhost:4567/load'
+mint_url: 'mintApp:4567/load'
 
 loader_jar: '../../loader/build/libs/loader.jar'
 


### PR DESCRIPTION
This PR mainly is about:

* separate mint playbooks to support different register lists,
* dockerized data loader instance to support longer data loads,
