### PR TITLE
removing engine_version param to rds

### DIFF
--- a/aws/modules/database/main.tf
+++ b/aws/modules/database/main.tf
@@ -12,7 +12,6 @@ resource "aws_db_instance" "db" {
   apply_immediately = "${var.apply_immediately}"
 
   engine = "${var.engine}"
-  engine_version = "${var.engine_version}"
 
   db_subnet_group_name = "${aws_db_subnet_group.subnet_group.id}"
   parameter_group_name = "${var.parameter_group_name}"

--- a/aws/modules/database/variables.tf
+++ b/aws/modules/database/variables.tf
@@ -40,10 +40,6 @@ variable "engine" {
   default = "postgres"
 }
 
-variable "engine_version" {
-  default = "9.4.1"
-}
-
 variable "instance_class" {
   default = "db.t2.micro"
 }


### PR DESCRIPTION
This prevents downgrading Postgres DB versions by Terraform.