### PR TITLE
hardcode the PASSWORD_STORE_DIR envvar

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,6 @@ On OSX you can install via brew:
 
 ## System variables
 
-* password store location:
-
-		export PASSWORD_STORE_DIR=~/.registers-pass
-
 * set AWS CLI variables:
 
 		export AWS_REGION=eu-west-1
@@ -117,11 +113,6 @@ To run a single playbook (ping in this example):
 
 (the ping command seems to timeout unless you explicitly run it
 serially (`-f 1`))
-
-Some tasks require fetching data from `pass`.  For this to work, you
-need to set up your environment first:
-
-    export PASSWORD_STORE_DIR=$HOME/.registers-pass
 
 
 ## Data loading

--- a/ansible/plugins/lookup/pass.py
+++ b/ansible/plugins/lookup/pass.py
@@ -3,6 +3,7 @@
 from __future__ import (absolute_import, division, print_function)
 from subprocess import check_output
 from ansible.plugins.lookup import LookupBase
+import os
 __metaclass__ = type
 
 
@@ -11,10 +12,12 @@ class LookupModule(LookupBase):
     def run(self, terms, varibles=None, **kwargs):
         result = []
 
+        env = os.environ.copy()
+        env['PASSWORD_STORE_DIR'] = '%s/.registers-pass' % os.getenv('HOME')
         for term in terms:
             var = term.split()[0]
 
-            out = check_output("pass " + var, shell=True).rstrip()
+            out = check_output("pass " + var, shell=True, env=env).rstrip()
             result.append(out)
 
         return result


### PR DESCRIPTION
everyone should store their cred store in this directory.  this means
you don't have to faff around with the environment variable to get
ansible to work for you.