### PR TITLE
bump to latest, minimal, amazon linux AMI

### DIFF
--- a/aws/modules/indexer/variables.tf
+++ b/aws/modules/indexer/variables.tf
@@ -7,7 +7,7 @@ variable "cidr_block" {}
 variable "db_cidr_block" {}
 
 variable "instance_ami" {
-  default = "ami-a10897d6"
+  default = "ami-6ced7f1f"
 }
 
 variable "instance_count" {

--- a/aws/modules/instance/variables.tf
+++ b/aws/modules/instance/variables.tf
@@ -6,7 +6,7 @@ variable "vpc_name" {}
 // Instance properties
 
 variable "instance_ami" {
-  default = "ami-a10897d6"
+  default = "ami-6ced7f1f"
 }
 
 variable "instance_count" {

--- a/aws/modules/mint/variables.tf
+++ b/aws/modules/mint/variables.tf
@@ -6,7 +6,7 @@ variable "cidr_block" {}
 variable "db_cidr_block" {}
 
 variable "instance_ami" {
-  default = "ami-a10897d6"
+  default = "ami-6ced7f1f"
 }
 
 variable "instance_count" {

--- a/aws/modules/presentation/variables.tf
+++ b/aws/modules/presentation/variables.tf
@@ -8,7 +8,7 @@ variable "db_cidr_block" {}
 variable "public_route_table_id" {}
 
 variable "instance_ami" {
-  default = "ami-a10897d6"
+  default = "ami-6ced7f1f"
 }
 
 variable "instance_type" {

--- a/aws/registers/user-data/users.yaml
+++ b/aws/registers/user-data/users.yaml
@@ -22,7 +22,9 @@ users:
 
 
 packages:
+  - aws-cli
   - docker
+  - ruby
 
 package_upgrade: true
 


### PR DESCRIPTION
This bumps us to the latest AMI for the latest Amazon linux release -
2016.03.2.  It also moves us to the "minimal" ami which is smaller and
comes with less stuff preinstalled.

As a result, we need to install "aws-cli" and "ruby" packages to ensure
the codedeploy agent setup code works.

I've tested this on the test register register presentation box.