### PR TITLE
Fix security group bug

### DIFF
--- a/aws/modules/core/nat_instance.tf
+++ b/aws/modules/core/nat_instance.tf
@@ -3,7 +3,7 @@ resource "aws_instance" "natgw" {
   instance_type = "${var.nat_instance_type}"
   subnet_id = "${element(aws_subnet.public.*.id, count.index)}"
   source_dest_check = false
-  security_groups = [ "${aws_security_group.natsg.id}" ]
+  vpc_security_group_ids = [ "${aws_security_group.natsg.id}" ]
   user_data = "${var.nat_user_data}"
   associate_public_ip_address = true
 

--- a/aws/modules/indexer/instance.tf
+++ b/aws/modules/indexer/instance.tf
@@ -4,7 +4,7 @@ resource "aws_instance" "indexer" {
   count = "${var.instance_count}"
   subnet_id = "${aws_subnet.indexer.id}"
   user_data = "${var.user_data}"
-  security_groups = [ "${aws_security_group.indexer.id}" ]
+  vpc_security_group_ids = [ "${aws_security_group.indexer.id}" ]
   iam_instance_profile = "${aws_iam_instance_profile.indexer.id}"
 
   tags = {

--- a/aws/modules/instance/main.tf
+++ b/aws/modules/instance/main.tf
@@ -4,7 +4,7 @@ resource "aws_instance" "instance" {
   instance_type = "${var.instance_type}"
   subnet_id = "${element(split(" ", var.subnet_ids), count.index)}"
   user_data = "${var.user_data}"
-  security_groups = [ "${split(" ", var.security_group_ids)}" ]
+  vpc_security_group_ids = [ "${split(" ", var.security_group_ids)}" ]
   iam_instance_profile = "${var.iam_instance_profile}"
 
   tags = {

--- a/aws/modules/mint/main.tf
+++ b/aws/modules/mint/main.tf
@@ -5,7 +5,7 @@ resource "aws_instance" "mint" {
   count = "${var.instance_count}"
   subnet_id = "${aws_subnet.mint.id}"
   user_data = "${var.user_data}"
-  security_groups = [ "${aws_security_group.mint.id}" ]
+  vpc_security_group_ids = [ "${aws_security_group.mint.id}" ]
   iam_instance_profile = "${aws_iam_instance_profile.mint_instance_profile.id}"
 
   tags = {


### PR DESCRIPTION
We were seeing weird behaviour where terraform was trying to rebuild
every AWS instance because terraform's state believed that the instances
didn't have needed security groups when in fact they did.

@joshmyers pointed out to us that this seems to be a bug in terraform
when using VPCs, and a simple workaround is to use the
`vpc_security_group_ids` property instead.