### PR TITLE
Specify instance root volume size for indexer

### DIFF
--- a/aws/modules/indexer/instance.tf
+++ b/aws/modules/indexer/instance.tf
@@ -7,6 +7,10 @@ resource "aws_instance" "indexer" {
   vpc_security_group_ids = [ "${aws_security_group.indexer.id}" ]
   iam_instance_profile = "${aws_iam_instance_profile.indexer.id}"
 
+  root_block_device = {
+    volume_size = "10" // gigabytes
+  }
+
   tags = {
     // should be this once we've fixed the app startup script to use the Register tag:
     // Name = "${var.vpc_name}-${var.id}-${count.index +1}"


### PR DESCRIPTION
In 63502ce86, we switched to the minimal AMI image. This had the
unintended side effect of reducing the root volume size everywhere to
2Gb, because when you don't specify the root volume size it seems to
default to the size of the AMI (or at least this is my theory).

As a result, we ended up unable to deploy the indexer because the root
filesystem was full.

Explicitly setting the root volume size fixes this.

Note that due to hashicorp/terraform#3941, this won't automatically
cause the instance to be reprovisioned.

Also note that this commit only changes the indexer instance, but all
instances are affected.