### PR TITLE
Upgrade address presentation instance

### DIFF
--- a/aws/modules/instance/main.tf
+++ b/aws/modules/instance/main.tf
@@ -7,6 +7,10 @@ resource "aws_instance" "instance" {
   vpc_security_group_ids = [ "${split(" ", var.security_group_ids)}" ]
   iam_instance_profile = "${var.iam_instance_profile}"
 
+  root_block_device = {
+    volume_size = "10" // gigabytes
+  }
+
   tags = {
     // should be this once we've fixed the app startup script to use the Register tag:
     // Name = "${var.vpc_name}-${var.id}-${count.index +1}"

--- a/aws/registers/register_address.tf
+++ b/aws/registers/register_address.tf
@@ -19,6 +19,7 @@ module "address_presentation" {
   security_group_ids = "${module.presentation.security_group_id}"
 
   instance_count = "${lookup(var.instance_count, "address")}"
+  instance_type = "t2.large"
   iam_instance_profile = "${module.address_policy.profile_name}"
 
   user_data = "${template_file.user_data.rendered}"


### PR DESCRIPTION
From t2.micro to t2.large to allow computation of Merkle Tree Hash on a large number of entries.