### PR TITLE
expose https port on elbs

### DIFF
--- a/ansible/roles/terraform_config/templates/register_template.tf.j2
+++ b/ansible/roles/terraform_config/templates/register_template.tf.j2
@@ -54,4 +54,5 @@ module "{{ item }}_elb" {
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
 }

--- a/aws/modules/load_balancer/main.tf
+++ b/aws/modules/load_balancer/main.tf
@@ -13,6 +13,14 @@ resource "aws_elb" "load_balancer" {
     lb_protocol = "http"
   }
 
+  listener = {
+    instance_port = "${var.instance_port}"
+    instance_protocol = "http"
+    lb_port = 443
+    lb_protocol = "https"
+    ssl_certificate_id = "${var.certificate_arn}"
+  }
+
   instances = [ "${split(" ", var.instance_ids)}" ]
 
   health_check {

--- a/aws/modules/load_balancer/security_group.tf
+++ b/aws/modules/load_balancer/security_group.tf
@@ -17,6 +17,13 @@ resource "aws_security_group" "load_balancer" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  ingress {
+    from_port = 443
+    to_port = 443
+    protocol = "TCP"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   egress {
     from_port = 80
     to_port = 80

--- a/aws/modules/load_balancer/variables.tf
+++ b/aws/modules/load_balancer/variables.tf
@@ -25,3 +25,5 @@ variable "dns_ttl" {
 variable "dns_domain" {
   default = "openregister.org"
 }
+
+variable "certificate_arn" {}

--- a/aws/registers/register_address.tf
+++ b/aws/registers/register_address.tf
@@ -55,4 +55,5 @@ module "address_elb" {
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
 }

--- a/aws/registers/register_company.tf
+++ b/aws/registers/register_company.tf
@@ -54,4 +54,5 @@ module "company_elb" {
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
 }

--- a/aws/registers/register_country.tf
+++ b/aws/registers/register_country.tf
@@ -54,4 +54,5 @@ module "country_elb" {
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
 }

--- a/aws/registers/register_datatype.tf
+++ b/aws/registers/register_datatype.tf
@@ -54,4 +54,5 @@ module "datatype_elb" {
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
 }

--- a/aws/registers/register_denomination.tf
+++ b/aws/registers/register_denomination.tf
@@ -54,4 +54,5 @@ module "denomination_elb" {
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
 }

--- a/aws/registers/register_diocese.tf
+++ b/aws/registers/register_diocese.tf
@@ -54,4 +54,5 @@ module "diocese_elb" {
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
 }

--- a/aws/registers/register_field.tf
+++ b/aws/registers/register_field.tf
@@ -54,4 +54,5 @@ module "field_elb" {
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
 }

--- a/aws/registers/register_food_premises.tf
+++ b/aws/registers/register_food_premises.tf
@@ -54,4 +54,5 @@ module "food-premises_elb" {
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
 }

--- a/aws/registers/register_food_premises_rating.tf
+++ b/aws/registers/register_food_premises_rating.tf
@@ -54,4 +54,5 @@ module "food-premises-rating_elb" {
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
 }

--- a/aws/registers/register_food_premises_type.tf
+++ b/aws/registers/register_food_premises_type.tf
@@ -54,4 +54,5 @@ module "food-premises-type_elb" {
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
 }

--- a/aws/registers/register_industry.tf
+++ b/aws/registers/register_industry.tf
@@ -54,4 +54,5 @@ module "industry_elb" {
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
 }

--- a/aws/registers/register_local_authority.tf
+++ b/aws/registers/register_local_authority.tf
@@ -54,4 +54,5 @@ module "local-authority_elb" {
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
 }

--- a/aws/registers/register_local_authority_type.tf
+++ b/aws/registers/register_local_authority_type.tf
@@ -54,4 +54,5 @@ module "local-authority-type_elb" {
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
 }

--- a/aws/registers/register_locality.tf
+++ b/aws/registers/register_locality.tf
@@ -54,4 +54,5 @@ module "locality_elb" {
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
 }

--- a/aws/registers/register_location.tf
+++ b/aws/registers/register_location.tf
@@ -54,4 +54,5 @@ module "location_elb" {
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
 }

--- a/aws/registers/register_place.tf
+++ b/aws/registers/register_place.tf
@@ -54,4 +54,5 @@ module "place_elb" {
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
 }

--- a/aws/registers/register_postcode.tf
+++ b/aws/registers/register_postcode.tf
@@ -54,4 +54,5 @@ module "postcode_elb" {
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
 }

--- a/aws/registers/register_premises.tf
+++ b/aws/registers/register_premises.tf
@@ -54,4 +54,5 @@ module "premises_elb" {
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
 }

--- a/aws/registers/register_public_body.tf
+++ b/aws/registers/register_public_body.tf
@@ -54,4 +54,5 @@ module "public-body_elb" {
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
 }

--- a/aws/registers/register_register.tf
+++ b/aws/registers/register_register.tf
@@ -54,4 +54,5 @@ module "register_elb" {
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
 }

--- a/aws/registers/register_school.tf
+++ b/aws/registers/register_school.tf
@@ -54,4 +54,5 @@ module "school_elb" {
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
 }

--- a/aws/registers/register_school_admissions_policy.tf
+++ b/aws/registers/register_school_admissions_policy.tf
@@ -54,4 +54,5 @@ module "school-admissions-policy_elb" {
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
 }

--- a/aws/registers/register_school_federation.tf
+++ b/aws/registers/register_school_federation.tf
@@ -54,4 +54,5 @@ module "school-federation_elb" {
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
 }

--- a/aws/registers/register_school_gender.tf
+++ b/aws/registers/register_school_gender.tf
@@ -54,4 +54,5 @@ module "school-gender_elb" {
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
 }

--- a/aws/registers/register_school_phase.tf
+++ b/aws/registers/register_school_phase.tf
@@ -54,4 +54,5 @@ module "school-phase_elb" {
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
 }

--- a/aws/registers/register_school_tag.tf
+++ b/aws/registers/register_school_tag.tf
@@ -54,4 +54,5 @@ module "school-tag_elb" {
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
 }

--- a/aws/registers/register_school_type.tf
+++ b/aws/registers/register_school_type.tf
@@ -54,4 +54,5 @@ module "school-type_elb" {
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
 }

--- a/aws/registers/register_street.tf
+++ b/aws/registers/register_street.tf
@@ -54,4 +54,5 @@ module "street_elb" {
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
 }

--- a/aws/registers/register_street_classification.tf
+++ b/aws/registers/register_street_classification.tf
@@ -54,4 +54,5 @@ module "street-classification_elb" {
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
 }

--- a/aws/registers/register_street_surface.tf
+++ b/aws/registers/register_street_surface.tf
@@ -54,4 +54,5 @@ module "street-surface_elb" {
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
 }

--- a/aws/registers/register_territory.tf
+++ b/aws/registers/register_territory.tf
@@ -54,4 +54,5 @@ module "territory_elb" {
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
 }

--- a/aws/registers/register_town.tf
+++ b/aws/registers/register_town.tf
@@ -54,4 +54,5 @@ module "town_elb" {
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
 }

--- a/aws/registers/register_uk.tf
+++ b/aws/registers/register_uk.tf
@@ -54,4 +54,5 @@ module "uk_elb" {
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
 }

--- a/aws/registers/variables.tf
+++ b/aws/registers/variables.tf
@@ -136,3 +136,6 @@ variable "instance_count" {
 variable "codedeploy_service_role_arn" {
   default = "arn:aws:iam::022990953738:role/code-deploy-role"
 }
+
+// https
+variable "elb_certificate_arn" {}


### PR DESCRIPTION
This change requires you to manually request a certificate in
Certificate Manager (or upload it to IAM) and put the ARN of the cert in
to the tfvars file.  This has been done for beta.