### PR TITLE
Add school-authority register config

### DIFF
--- a/ansible/group_vars/tag_Environment_discovery
+++ b/ansible/group_vars/tag_Environment_discovery
@@ -20,6 +20,7 @@ registers:
   - premises
   - register
   - school-admissions-policy
+  - school-authority
   - school-federation
   - school-gender
   - school-phase

--- a/ansible/roles/service_data/vars/data-sources.yml
+++ b/ansible/roles/service_data/vars/data-sources.yml
@@ -153,3 +153,8 @@ sources:
     src_data: '../../school-data/data/school-type/school-types.tsv'
     src_type: tsv
     target: school-types.tsv
+
+  school-authority:
+    src_data: '../../school-data/data/school-authority/school-authority.tsv'
+    src_type: tsv
+    target: school-authority.tsv

--- a/ansible/roles/terraform_config/templates/register_template.tf.j2
+++ b/ansible/roles/terraform_config/templates/register_template.tf.j2
@@ -7,40 +7,6 @@ module "{{ item }}_policy" {
   vpc_id = "${module.core.vpc_id}"
 }
 
-module "{{ item }}_presentation" {
-  source = "../modules/instance"
-  id = "{{ item }}"
-  role = "presentation_app"
-
-  vpc_name = "${var.vpc_name}"
-  vpc_id = "${module.core.vpc_id}"
-
-  subnet_ids = "${module.presentation.subnet_ids}"
-  security_group_ids = "${module.presentation.security_group_id}"
-
-  instance_count = "${lookup(var.instance_count, "{{ item }}")}"
-  iam_instance_profile = "${module.{{ item }}_policy.profile_name}"
-
-  user_data = "${template_file.user_data.rendered}"
-}
-
-module "{{ item }}_mint" {
-  source = "../modules/instance"
-  id = "{{ item }}"
-  role = "mint_app"
-
-  vpc_name = "${var.vpc_name}"
-  vpc_id = "${module.core.vpc_id}"
-
-  subnet_ids = "${module.mint.subnet_ids}"
-  security_group_ids = "${module.mint.security_group_id}"
-
-  instance_count = "${signum(lookup(var.instance_count, "{{ item }}"))}"
-  iam_instance_profile = "${module.{{ item }}_policy.profile_name}"
-
-  user_data = "${template_file.user_data.rendered}"
-}
-
 module "{{ item }}_openregister" {
   source = "../modules/instance"
   id = "{{ item }}"

--- a/ansible/roles/terraform_config/templates/register_template.tf.j2
+++ b/ansible/roles/terraform_config/templates/register_template.tf.j2
@@ -32,8 +32,8 @@ module "{{ item }}_elb" {
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
 
-  instance_ids = "${module.{{ item }}_presentation.instance_ids}"
-  security_group_ids = "${module.presentation.security_group_id}"
+  instance_ids = "${module.{{ item }}_openregister.instance_ids}"
+  security_group_ids = "${module.openregister.security_group_id}"
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"

--- a/aws/registers/register_school_authority.tf
+++ b/aws/registers/register_school_authority.tf
@@ -1,0 +1,58 @@
+module "school-authority_policy" {
+  source = "../modules/instance_policy"
+  id = "school-authority"
+  enabled = "${signum(lookup(var.instance_count, "school-authority"))}"
+
+  vpc_name = "${var.vpc_name}"
+  vpc_id = "${module.core.vpc_id}"
+}
+
+module "school-authority_presentation" {
+  source = "../modules/instance"
+  id = "school-authority"
+  role = "presentation_app"
+
+  vpc_name = "${var.vpc_name}"
+  vpc_id = "${module.core.vpc_id}"
+
+  subnet_ids = "${module.presentation.subnet_ids}"
+  security_group_ids = "${module.presentation.security_group_id}"
+
+  instance_count = "${lookup(var.instance_count, "school-authority")}"
+  iam_instance_profile = "${module.school-authority_policy.profile_name}"
+
+  user_data = "${template_file.user_data.rendered}"
+}
+
+module "school-authority_mint" {
+  source = "../modules/instance"
+  id = "school-authority"
+  role = "mint_app"
+
+  vpc_name = "${var.vpc_name}"
+  vpc_id = "${module.core.vpc_id}"
+
+  subnet_ids = "${module.mint.subnet_ids}"
+  security_group_ids = "${module.mint.security_group_id}"
+
+  instance_count = "${signum(lookup(var.instance_count, "school-authority"))}"
+  iam_instance_profile = "${module.school-authority_policy.profile_name}"
+
+  user_data = "${template_file.user_data.rendered}"
+}
+
+module "school-authority_elb" {
+  source = "../modules/load_balancer"
+  id = "school-authority"
+  enabled = "${signum(lookup(var.instance_count, "school-authority"))}"
+
+  vpc_name = "${var.vpc_name}"
+  vpc_id = "${module.core.vpc_id}"
+
+  instance_ids = "${module.school-authority_presentation.instance_ids}"
+  security_group_ids = "${module.presentation.security_group_id}"
+  subnet_ids = "${module.core.public_subnet_ids}"
+
+  dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
+}

--- a/aws/registers/register_school_authority.tf
+++ b/aws/registers/register_school_authority.tf
@@ -32,8 +32,8 @@ module "school-authority_elb" {
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
 
-  instance_ids = "${module.school-authority_presentation.instance_ids}"
-  security_group_ids = "${module.presentation.security_group_id}"
+  instance_ids = "${module.school-authority_openregister.instance_ids}"
+  security_group_ids = "${module.openregister.security_group_id}"
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"

--- a/aws/registers/register_school_authority.tf
+++ b/aws/registers/register_school_authority.tf
@@ -7,35 +7,18 @@ module "school-authority_policy" {
   vpc_id = "${module.core.vpc_id}"
 }
 
-module "school-authority_presentation" {
+module "school-authority_openregister" {
   source = "../modules/instance"
   id = "school-authority"
-  role = "presentation_app"
+  role = "openregister_app"
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
 
-  subnet_ids = "${module.presentation.subnet_ids}"
-  security_group_ids = "${module.presentation.security_group_id}"
+  subnet_ids = "${module.openregister.subnet_ids}"
+  security_group_ids = "${module.openregister.security_group_id}"
 
   instance_count = "${lookup(var.instance_count, "school-authority")}"
-  iam_instance_profile = "${module.school-authority_policy.profile_name}"
-
-  user_data = "${template_file.user_data.rendered}"
-}
-
-module "school-authority_mint" {
-  source = "../modules/instance"
-  id = "school-authority"
-  role = "mint_app"
-
-  vpc_name = "${var.vpc_name}"
-  vpc_id = "${module.core.vpc_id}"
-
-  subnet_ids = "${module.mint.subnet_ids}"
-  security_group_ids = "${module.mint.security_group_id}"
-
-  instance_count = "${signum(lookup(var.instance_count, "school-authority"))}"
   iam_instance_profile = "${module.school-authority_policy.profile_name}"
 
   user_data = "${template_file.user_data.rendered}"

--- a/aws/registers/variables.tf
+++ b/aws/registers/variables.tf
@@ -102,6 +102,7 @@ variable "instance_count" {
     "diocese" = 0
     "school" = 0
     "school-admissions-policy" = 0
+    "school-authority" = 0
     "school-federation" = 0
     "school-gender" = 0
     "school-phase" = 0


### PR DESCRIPTION
The school-authority register is a new register to represent the organisation that has authority over a school.

Initially it'll be deployed to `discovery` after the local-authority register has been split into separate registers for England, Wales, etc.