### PR TITLE
Food discovery registers

### DIFF
--- a/ansible/group_vars/tag_Environment_discovery
+++ b/ansible/group_vars/tag_Environment_discovery
@@ -1,12 +1,22 @@
 registers:
   - address
+  - company
   - denomination
   - diocese
   - datatype
   - field
+  - food-authority
+  - food-premises
+  - food-premises-rating
+  - industry
   - local-authority
+  - local-authority-eng
+  - local-authority-nir
+  - local-authority-sct
+  - local-authority-wls
   - local-authority-type
   - place
+  - premises
   - register
   - school-admissions-policy
   - school-federation

--- a/ansible/group_vars/tag_Environment_discovery
+++ b/ansible/group_vars/tag_Environment_discovery
@@ -8,6 +8,7 @@ registers:
   - food-authority
   - food-premises
   - food-premises-rating
+  - food-premises-type
   - industry
   - local-authority
   - local-authority-eng

--- a/ansible/roles/service_data/vars/data-sources.yml
+++ b/ansible/roles/service_data/vars/data-sources.yml
@@ -51,12 +51,32 @@ sources:
     src_type: tsv
     target: local-authorities.tsv
 
+  local-authority-nir:
+    src_data: '../../local-authority-data/data/local-authority-nir/local-authorities.tsv'
+    src_type: tsv
+    target: local-authorities.tsv
+
+  local-authority-sct:
+    src_data: '../../local-authority-data/data/local-authority-sct/local-authorities.tsv'
+    src_type: tsv
+    target: local-authorities.tsv
+
+  local-authority-wls:
+    src_data: '../../local-authority-data/data/local-authority-wls/local-authorities.tsv'
+    src_type: tsv
+    target: local-authorities.tsv
+
   local-authority-type:
     src_data: '../../local-authority-data/data/local-authority-type/local-authority-types.tsv'
     src_type: tsv
     target: local-authority-types.tsv
 
 # Food Standard Agency
+  food-authority:
+    src_data: '../../food-data/ratings/data/food-authority/food-authority.tsv'
+    src_type: tsv
+    target: food-authority.tsv  
+
   food-premises:
     src_data: '../../food-data/ratings/fixed/food-premises.tsv'
     src_type: tsv

--- a/aws/registers/register_food_authority.tf
+++ b/aws/registers/register_food_authority.tf
@@ -1,0 +1,41 @@
+module "food-authority_policy" {
+  source = "../modules/instance_policy"
+  id = "food-authority"
+  enabled = "${signum(lookup(var.instance_count, "food-authority"))}"
+
+  vpc_name = "${var.vpc_name}"
+  vpc_id = "${module.core.vpc_id}"
+}
+
+module "food-authority_openregister" {
+  source = "../modules/instance"
+  id = "food-authority"
+  role = "openregister_app"
+
+  vpc_name = "${var.vpc_name}"
+  vpc_id = "${module.core.vpc_id}"
+
+  subnet_ids = "${module.openregister.subnet_ids}"
+  security_group_ids = "${module.openregister.security_group_id}"
+
+  instance_count = "${lookup(var.instance_count, "food-authority")}"
+  iam_instance_profile = "${module.food-authority_policy.profile_name}"
+
+  user_data = "${template_file.user_data.rendered}"
+}
+
+module "food-authority_elb" {
+  source = "../modules/load_balancer"
+  id = "food-authority"
+  enabled = "${signum(lookup(var.instance_count, "food-authority"))}"
+
+  vpc_name = "${var.vpc_name}"
+  vpc_id = "${module.core.vpc_id}"
+
+  instance_ids = "${module.food-authority_openregister.instance_ids}"
+  security_group_ids = "${module.openregister.security_group_id}"
+  subnet_ids = "${module.core.public_subnet_ids}"
+
+  dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
+}

--- a/aws/registers/register_local_authority_nir.tf
+++ b/aws/registers/register_local_authority_nir.tf
@@ -1,0 +1,41 @@
+module "local-authority-nir_policy" {
+  source = "../modules/instance_policy"
+  id = "local-authority-nir"
+  enabled = "${signum(lookup(var.instance_count, "local-authority-nir"))}"
+
+  vpc_name = "${var.vpc_name}"
+  vpc_id = "${module.core.vpc_id}"
+}
+
+module "local-authority-nir_openregister" {
+  source = "../modules/instance"
+  id = "local-authority-nir"
+  role = "openregister_app"
+
+  vpc_name = "${var.vpc_name}"
+  vpc_id = "${module.core.vpc_id}"
+
+  subnet_ids = "${module.openregister.subnet_ids}"
+  security_group_ids = "${module.openregister.security_group_id}"
+
+  instance_count = "${lookup(var.instance_count, "local-authority-nir")}"
+  iam_instance_profile = "${module.local-authority-nir_policy.profile_name}"
+
+  user_data = "${template_file.user_data.rendered}"
+}
+
+module "local-authority-nir_elb" {
+  source = "../modules/load_balancer"
+  id = "local-authority-nir"
+  enabled = "${signum(lookup(var.instance_count, "local-authority-nir"))}"
+
+  vpc_name = "${var.vpc_name}"
+  vpc_id = "${module.core.vpc_id}"
+
+  instance_ids = "${module.local-authority-nir_openregister.instance_ids}"
+  security_group_ids = "${module.openregister.security_group_id}"
+  subnet_ids = "${module.core.public_subnet_ids}"
+
+  dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
+}

--- a/aws/registers/register_local_authority_sct.tf
+++ b/aws/registers/register_local_authority_sct.tf
@@ -1,0 +1,41 @@
+module "local-authority-sct_policy" {
+  source = "../modules/instance_policy"
+  id = "local-authority-sct"
+  enabled = "${signum(lookup(var.instance_count, "local-authority-sct"))}"
+
+  vpc_name = "${var.vpc_name}"
+  vpc_id = "${module.core.vpc_id}"
+}
+
+module "local-authority-sct_openregister" {
+  source = "../modules/instance"
+  id = "local-authority-sct"
+  role = "openregister_app"
+
+  vpc_name = "${var.vpc_name}"
+  vpc_id = "${module.core.vpc_id}"
+
+  subnet_ids = "${module.openregister.subnet_ids}"
+  security_group_ids = "${module.openregister.security_group_id}"
+
+  instance_count = "${lookup(var.instance_count, "local-authority-sct")}"
+  iam_instance_profile = "${module.local-authority-sct_policy.profile_name}"
+
+  user_data = "${template_file.user_data.rendered}"
+}
+
+module "local-authority-sct_elb" {
+  source = "../modules/load_balancer"
+  id = "local-authority-sct"
+  enabled = "${signum(lookup(var.instance_count, "local-authority-sct"))}"
+
+  vpc_name = "${var.vpc_name}"
+  vpc_id = "${module.core.vpc_id}"
+
+  instance_ids = "${module.local-authority-sct_openregister.instance_ids}"
+  security_group_ids = "${module.openregister.security_group_id}"
+  subnet_ids = "${module.core.public_subnet_ids}"
+
+  dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
+}

--- a/aws/registers/register_local_authority_wls.tf
+++ b/aws/registers/register_local_authority_wls.tf
@@ -1,0 +1,41 @@
+module "local-authority-wls_policy" {
+  source = "../modules/instance_policy"
+  id = "local-authority-wls"
+  enabled = "${signum(lookup(var.instance_count, "local-authority-wls"))}"
+
+  vpc_name = "${var.vpc_name}"
+  vpc_id = "${module.core.vpc_id}"
+}
+
+module "local-authority-wls_openregister" {
+  source = "../modules/instance"
+  id = "local-authority-wls"
+  role = "openregister_app"
+
+  vpc_name = "${var.vpc_name}"
+  vpc_id = "${module.core.vpc_id}"
+
+  subnet_ids = "${module.openregister.subnet_ids}"
+  security_group_ids = "${module.openregister.security_group_id}"
+
+  instance_count = "${lookup(var.instance_count, "local-authority-wls")}"
+  iam_instance_profile = "${module.local-authority-wls_policy.profile_name}"
+
+  user_data = "${template_file.user_data.rendered}"
+}
+
+module "local-authority-wls_elb" {
+  source = "../modules/load_balancer"
+  id = "local-authority-wls"
+  enabled = "${signum(lookup(var.instance_count, "local-authority-wls"))}"
+
+  vpc_name = "${var.vpc_name}"
+  vpc_id = "${module.core.vpc_id}"
+
+  instance_ids = "${module.local-authority-wls_openregister.instance_ids}"
+  security_group_ids = "${module.openregister.security_group_id}"
+  subnet_ids = "${module.core.public_subnet_ids}"
+
+  dns_zone_id = "${module.core.dns_zone_id}"
+  certificate_arn = "${var.elb_certificate_arn}"
+}

--- a/aws/registers/variables.tf
+++ b/aws/registers/variables.tf
@@ -111,10 +111,14 @@ variable "instance_count" {
     // Department for Communities and Local Government registers
     "local-authority" = 0
     "local-authority-eng" = 0
+    "local-authority-nir" = 0
+    "local-authority-sct" = 0
+    "local-authority-wls" = 0
     "local-authority-type" = 0
 
     // Food Standards Agency registers
     "location" = 0
+    "food-authority" = 0
     "food-premises" = 0
     "food-premises-type" = 0
     "food-premises-rating" = 0


### PR DESCRIPTION
Create food-premises registers in discovery so that they can later be removed from the alpha environment.

Also add new local-authority registers to discovery.