### PR TITLE
Migrate register instances to openregister

### DIFF
--- a/ansible/roles/service_data/vars/data-sources.yml
+++ b/ansible/roles/service_data/vars/data-sources.yml
@@ -19,13 +19,13 @@ sources:
 
 # Companies House
   company:
-    src_data: '../../food-data/ratings/fixed/company.tsv'
+    src_data: '../../food-ratings-data/data/demo/company.tsv'
     src_type: tsv
     target: company.tsv
 
 # Valuation Office Agency
   premises:
-    src_data: '../../food-data/ratings/fixed/premises.tsv'
+    src_data: '../../food-ratings-data/data/demo/premises.tsv'
     src_type: tsv
     target: premises.tsv
 
@@ -78,20 +78,20 @@ sources:
     target: food-authority.tsv  
 
   food-premises:
-    src_data: '../../food-data/ratings/fixed/food-premises.tsv'
+    src_data: '../../food-ratings-data/data/food-premises/food-premises.tsv'
     src_type: tsv
     target: food-premises.tsv
 
   food-premises-rating:
-    src_data: '../../food-data/ratings/data/food-premises-rating.tsv'
+    src_data: '../../food-ratings-data/data/food-premises-rating/food-premises-rating.tsv'
     src_type: tsv
     target: food-premises-rating.tsv
 
 # Office for National Statistics
   address:
-    src_data: '../../address-data/data/address.tsv'
+    src_data: '../../school-data/data/address/addresses.tsv'
     src_type: tsv
-    target: address.tsv
+    target: addresses.tsv
 
   industry:
     src_data: '../../industry-data/data/industry/industry.tsv'

--- a/aws/registers/register_address.tf
+++ b/aws/registers/register_address.tf
@@ -68,8 +68,8 @@ module "address_elb" {
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
 
-  instance_ids = "${module.address_presentation.instance_ids}"
-  security_group_ids = "${module.presentation.security_group_id}"
+  instance_ids = "${module.address_openregister.instance_ids}"
+  security_group_ids = "${module.openregister.security_group_id}"
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"

--- a/aws/registers/register_local_authority.tf
+++ b/aws/registers/register_local_authority.tf
@@ -7,40 +7,6 @@ module "local-authority_policy" {
   vpc_id = "${module.core.vpc_id}"
 }
 
-module "local-authority_presentation" {
-  source = "../modules/instance"
-  id = "local-authority"
-  role = "presentation_app"
-
-  vpc_name = "${var.vpc_name}"
-  vpc_id = "${module.core.vpc_id}"
-
-  subnet_ids = "${module.presentation.subnet_ids}"
-  security_group_ids = "${module.presentation.security_group_id}"
-
-  instance_count = "${lookup(var.instance_count, "local-authority")}"
-  iam_instance_profile = "${module.local-authority_policy.profile_name}"
-
-  user_data = "${template_file.user_data.rendered}"
-}
-
-module "local-authority_mint" {
-  source = "../modules/instance"
-  id = "local-authority"
-  role = "mint_app"
-
-  vpc_name = "${var.vpc_name}"
-  vpc_id = "${module.core.vpc_id}"
-
-  subnet_ids = "${module.mint.subnet_ids}"
-  security_group_ids = "${module.mint.security_group_id}"
-
-  instance_count = "${signum(lookup(var.instance_count, "local-authority"))}"
-  iam_instance_profile = "${module.local-authority_policy.profile_name}"
-
-  user_data = "${template_file.user_data.rendered}"
-}
-
 module "local-authority_openregister" {
   source = "../modules/instance"
   id = "local-authority"
@@ -66,8 +32,8 @@ module "local-authority_elb" {
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
 
-  instance_ids = "${module.local-authority_presentation.instance_ids}"
-  security_group_ids = "${module.presentation.security_group_id}"
+  instance_ids = "${module.local-authority_openregister.instance_ids}"
+  security_group_ids = "${module.openregister.security_group_id}"
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"

--- a/aws/registers/register_street.tf
+++ b/aws/registers/register_street.tf
@@ -7,40 +7,6 @@ module "street_policy" {
   vpc_id = "${module.core.vpc_id}"
 }
 
-module "street_presentation" {
-  source = "../modules/instance"
-  id = "street"
-  role = "presentation_app"
-
-  vpc_name = "${var.vpc_name}"
-  vpc_id = "${module.core.vpc_id}"
-
-  subnet_ids = "${module.presentation.subnet_ids}"
-  security_group_ids = "${module.presentation.security_group_id}"
-
-  instance_count = "${lookup(var.instance_count, "street")}"
-  iam_instance_profile = "${module.street_policy.profile_name}"
-
-  user_data = "${template_file.user_data.rendered}"
-}
-
-module "street_mint" {
-  source = "../modules/instance"
-  id = "street"
-  role = "mint_app"
-
-  vpc_name = "${var.vpc_name}"
-  vpc_id = "${module.core.vpc_id}"
-
-  subnet_ids = "${module.mint.subnet_ids}"
-  security_group_ids = "${module.mint.security_group_id}"
-
-  instance_count = "${signum(lookup(var.instance_count, "street"))}"
-  iam_instance_profile = "${module.street_policy.profile_name}"
-
-  user_data = "${template_file.user_data.rendered}"
-}
-
 module "street_openregister" {
   source = "../modules/instance"
   id = "street"

--- a/aws/registers/register_street.tf
+++ b/aws/registers/register_street.tf
@@ -66,8 +66,8 @@ module "street_elb" {
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
 
-  instance_ids = "${module.street_presentation.instance_ids}"
-  security_group_ids = "${module.presentation.security_group_id}"
+  instance_ids = "${module.street_openregister.instance_ids}"
+  security_group_ids = "${module.openregister.security_group_id}"
   subnet_ids = "${module.core.public_subnet_ids}"
 
   dns_zone_id = "${module.core.dns_zone_id}"

--- a/aws/registers/write_api.tf
+++ b/aws/registers/write_api.tf
@@ -11,7 +11,7 @@ module "indexer" {
   nat_gateway_id = "${module.core.nat_gateway_id}"
   nat_private_ip = "${module.core.nat_private_ip}"
 
-  instance_count = 1
+  instance_count = 0
   user_data = "${template_file.user_data.rendered}"
 }
 


### PR DESCRIPTION
These are the last few EC2 instances to migrate to openregister-java or switch off.

Address mint/presentation in discovery/test have not yet been destroyed just in case loading the new address register in test proves difficult. Once this is done, these can be destroyed - they are the last mint/presentation EC2 instances left.

Mint/presentation RDS instances have not been destroyed yet for the same reason but can be done as a separate task later on.