### PR TITLE
Fix create-databases.yml inventory

### DIFF
--- a/ansible/create_databases.yml
+++ b/ansible/create_databases.yml
@@ -1,9 +1,7 @@
 ---
 - name: Create databases
   hosts:
-    - '&tag_Environment_{{ vpc | normalize_ec2_tags }}'
-    - '&tag_Register_territory' # FIXME
-    - '&tag_Role_openregister_app' # FIXME
+    - 'tag_DeploymentGroup_{{ vpc | normalize_ec2_tags }}_openregister_app[0]'
 
   environment:
     PASSWORD_STORE_DIR: "{{ pass_store_location | expanduser }}"


### PR DESCRIPTION
The create-databases.yml script needs to run on a machine which is able
to contact the RDS instance.  It only needs to run once though, so we
need to select only a single machine to run on.

Back in the mists of time (ie before 0f36a2ae5), this script did so by
running on the `indexer` instance, using the `tag_Role_indexer_app`
inventory group.  This was ideal because: 1) it had security group
permissions to see the appropriate RDS instances, and 2) there was only
one indexer instance in each environment so the scripts would only run
once.

In 0f36a2ae5 we moved from the old mint/indexer/presentation
architecture to the new monolithic architecture.  In doing so, we lost
our single unique indexer instance per environment.  At the time, I
bodged it by picking the territory register tag in order to select a
single instance; however this was flawed as the territory register
doesn't exist in all environments.

This commit resolves the issue by using ansible pattern subscripting.
We move from using the Environment/Role tags to using the
DeploymentGroup tag (which is semantically the same thing).  We then
subscript on this group to pick a single arbitrary instance from the
group.  This results in something like:
`tag_DeploymentGroup_alpha_openregister_app[0]` to select the "first"
openregister_app server in the alpha environment.

I tested this locally by replacing the actual database creation command
with a `debug` task in order to just show which hosts were selected
without actually doing any destructive changes.