### PR TITLE
Remove traces of mint/indexer/presentation from pw gen

### DIFF
--- a/ansible/create_databases.yml
+++ b/ansible/create_databases.yml
@@ -12,8 +12,6 @@
   roles:
     - { role: database,
         inventory_group_name: '{{ vpc }}-openregister-db',
-        read_user: 'openregister',
-        write_user: 'openregister',
         master_password: "{{ lookup('pass', '{{ vpc }}/rds/openregister/master') }}"
       }
 

--- a/ansible/generate_passwords.yml
+++ b/ansible/generate_passwords.yml
@@ -9,11 +9,6 @@
     password_length: 10
     app_services:
       - mint
-    rds_services:
-      - indexer
-      - mint
-      - presentation
-      - openregister
 
   tasks:
     - stat: path="group_vars/tag_Environment_{{ vpc }}"
@@ -31,9 +26,8 @@
         - "{{ app_services }}"
 
     - name: Generate RDS passwords
-      command: "pass generate --no-symbols {{ vpc }}/rds/{{ item.1 }}/{{ item.0 }} {{ password_length }}"
+      command: "pass generate --no-symbols {{ vpc }}/rds/openregister/{{ item }} {{ password_length }}"
       args:
-        creates: "{{ pass_store_location | expanduser }}/{{ vpc }}/rds/{{ item.1 }}/{{ item.0 }}.gpg"
-      with_nested:
+        creates: "{{ pass_store_location | expanduser }}/{{ vpc }}/rds/openregister/{{ item }}.gpg"
+      with_items:
         - "{{ registers | union(['master']) }}"
-        - "{{ rds_services }}"

--- a/ansible/roles/database/tasks/main.yml
+++ b/ansible/roles/database/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Install python depedencies
+- name: Install python dependencies
   yum: name="{{ item }}" state=installed
   become: true
   become_user: 'root'

--- a/ansible/roles/database/tasks/user.yml
+++ b/ansible/roles/database/tasks/user.yml
@@ -2,10 +2,10 @@
   postgresql_user: >
     state=present
     db="{{ item }}"
-    name="{{ item }}_{{ write_user }}"
+    name="{{ item }}_openregister"
     priv=CONNECT
     role_attr_flags=NOCREATEROLE,NOCREATEUSER,NOCREATEDB,INHERIT,LOGIN,NOREPLICATION
-    password="{{ lookup('pass', '{{ vpc }}/rds/{{ write_user }}/{{ item }}') }}"
+    password="{{ lookup('pass', '{{ vpc }}/rds/openregister/{{ item }}') }}"
     no_password_changes=yes
     login_host="{{ groups[inventory_group_name][0] }}"
     login_user="{{ master_user }}"
@@ -17,10 +17,10 @@
   postgresql_privs:
     state=present
     db="{{ item }}"
-    roles="{{ item }}_{{ write_user }}"
+    roles="{{ item }}_openregister"
     objs=ALL_IN_SCHEMA
     privs=ALL
     login_host="{{ groups[inventory_group_name][0] }}"
-    login_user="{{ item }}_{{ write_user }}"
-    login_password="{{ lookup('pass', '{{ vpc }}/rds/{{ write_user }}/{{ item }}') }}"
+    login_user="{{ item }}_openregister"
+    login_password="{{ lookup('pass', '{{ vpc }}/rds/openregister/{{ item }}') }}"
   with_items: "{{ registers }}"


### PR DESCRIPTION
In particular:

 - in generate_passwords.yml, don't generate db passwords for
   mint/indexer/presentation
 - remove previously-configurable paths; we only need
   rds/openregister/<register>.gpg now