### PR TITLE
Use native lists where possible

### DIFF
--- a/aws/modules/core/outputs.tf
+++ b/aws/modules/core/outputs.tf
@@ -51,7 +51,7 @@ output "public_route_table_id" {
 }
 
 output "public_subnet_ids" {
-  value = "${join(" ", aws_subnet.public.*.id)}"
+  value = ["${aws_subnet.public.*.id}"]
 }
 
 /*

--- a/aws/modules/instance/main.tf
+++ b/aws/modules/instance/main.tf
@@ -2,7 +2,7 @@ resource "aws_instance" "instance" {
   count = "${var.instance_count}"
   ami = "${var.instance_ami}"
   instance_type = "${var.instance_type}"
-  subnet_id = "${element(split(" ", var.subnet_ids), count.index)}"
+  subnet_id = "${element(var.subnet_ids, count.index)}"
   user_data = "${var.user_data}"
   vpc_security_group_ids = [ "${split(" ", var.security_group_ids)}" ]
   iam_instance_profile = "${var.iam_instance_profile}"

--- a/aws/modules/instance/outputs.tf
+++ b/aws/modules/instance/outputs.tf
@@ -1,3 +1,3 @@
 output "instance_ids" {
-  value = "${join(" ", aws_instance.instance.*.id)}"
+  value = ["${aws_instance.instance.*.id}"]
 }

--- a/aws/modules/instance/variables.tf
+++ b/aws/modules/instance/variables.tf
@@ -28,6 +28,6 @@ variable "zones" {
 }
 
 variable "user_data" {}
-variable "subnet_ids" {}
+variable "subnet_ids" { type = "list" }
 
 variable "security_group_ids" {}

--- a/aws/modules/load_balancer/main.tf
+++ b/aws/modules/load_balancer/main.tf
@@ -3,7 +3,7 @@ resource "aws_elb" "load_balancer" {
 
   # replace discovery with disco to ensure name does not exceed string length limit
   name = "${replace(format("%s-%s", replace(var.vpc_name,"discovery","disco"), var.id),"_","-")}"
-  subnets = [ "${split(" ", var.subnet_ids)}" ]
+  subnets = [ "${var.subnet_ids}" ]
   security_groups = ["${aws_security_group.load_balancer.id}"]
 
   listener = {

--- a/aws/modules/load_balancer/main.tf
+++ b/aws/modules/load_balancer/main.tf
@@ -21,7 +21,7 @@ resource "aws_elb" "load_balancer" {
     ssl_certificate_id = "${var.certificate_arn}"
   }
 
-  instances = [ "${split(" ", var.instance_ids)}" ]
+  instances = ["${var.instance_ids}"]
 
   health_check {
     healthy_threshold = 2

--- a/aws/modules/load_balancer/variables.tf
+++ b/aws/modules/load_balancer/variables.tf
@@ -8,7 +8,7 @@ variable "instance_port" {
 
 variable "enabled" { default = 1 }
 
-variable "subnet_ids" {}
+variable "subnet_ids" { type = "list" }
 variable "instance_ids" { type = "list" }
 variable "security_group_ids" {}
 

--- a/aws/modules/load_balancer/variables.tf
+++ b/aws/modules/load_balancer/variables.tf
@@ -9,7 +9,7 @@ variable "instance_port" {
 variable "enabled" { default = 1 }
 
 variable "subnet_ids" {}
-variable "instance_ids" {}
+variable "instance_ids" { type = "list" }
 variable "security_group_ids" {}
 
 /*

--- a/aws/modules/openregister/outputs.tf
+++ b/aws/modules/openregister/outputs.tf
@@ -3,7 +3,7 @@ output "cidr_block" {
 }
 
 output "subnet_ids" {
-  value = "${join(" ", aws_subnet.openregister.*.id)}"
+  value = ["${aws_subnet.openregister.*.id}"]
 }
 
 output "security_group_id" {


### PR DESCRIPTION
Based on the migration guide: https://www.terraform.io/upgrade-guides/0-7.html#migrating-to-native-lists-and-maps

We had a few modules which output list-type values as join()ed strings,
as this was all you could do in terraform 0.6.  Version 0.7 introduces
native lists as a type.  This converts some old usages to the new native
list type.

Things *not* done:

 - the mint or presentation modules, as their days are numbered
 - the variables which are configured through .tfvars, which will need
   more care
