### PR TITLE
Migrate to terraform 0.7 map format

### DIFF
--- a/aws/tls-certs/terraform.tfvars
+++ b/aws/tls-certs/terraform.tfvars
@@ -1,6 +1,8 @@
-beta.enabled = 1
-beta.name = "register.gov.uk"
-beta.path = "/cloudfront/"
-beta.certificate = "../../tls-certs/beta/certificates/register.gov.uk.pem_00"
-beta.chain = "../../tls-certs/beta/certificates/register.gov.uk.pem_01"
-beta.private_key = "../../tls-certs/beta/certificates/register.gov.uk.key"
+beta = {
+  enabled = 1
+  name = "register.gov.uk"
+  path = "/cloudfront/"
+  certificate = "../../tls-certs/beta/certificates/register.gov.uk.pem_00"
+  chain = "../../tls-certs/beta/certificates/register.gov.uk.pem_01"
+  private_key = "../../tls-certs/beta/certificates/register.gov.uk.key"
+}


### PR DESCRIPTION
part of: https://trello.com/c/qyVI1azF/387-upgrade-terraform-to-version-0-7