### PR TITLE
specify fieldsurl in loader

### DIFF
--- a/ansible/roles/service_data/tasks/docker.yml
+++ b/ansible/roles/service_data/tasks/docker.yml
@@ -18,6 +18,7 @@
       --type={{ type }}
       --datasource={{ datasource }}
       --minturl=http://{{ mint_user }}:{{ mint_password }}@{{ mint_url }}
+      --fieldsurl=https://field.{{ register_domain }}/records.json
 
     links: openregister
 


### PR DESCRIPTION
If you're loading a register with fields which have `cardinality:n` then
the loader needs to know this.  It gets this info from the fields register.