### PR TITLE
Default all subnets to /24 in new environments

### DIFF
--- a/ansible/roles/terraform_config/templates/environment.tfvars.j2
+++ b/ansible/roles/terraform_config/templates/environment.tfvars.j2
@@ -3,9 +3,9 @@ vpc_cidr_block = "{{ vpc_cidr_block }}"
 
 admin_ips = "{{ admin_ips }}"
 
-{% set public_cidr_block_default_a = vpc_cidr_block | ipsubnet(27, 80) -%}
-{% set public_cidr_block_default_b = vpc_cidr_block | ipsubnet(27, 81) -%}
-{% set public_cidr_block_default_c = vpc_cidr_block | ipsubnet(27, 82) -%}
+{% set public_cidr_block_default_a = vpc_cidr_block | ipsubnet(24, 1) -%}
+{% set public_cidr_block_default_b = vpc_cidr_block | ipsubnet(24, 2) -%}
+{% set public_cidr_block_default_c = vpc_cidr_block | ipsubnet(24, 3) -%}
 {% set public_cidr_block_defaults = [
   public_cidr_block_default_a,
   public_cidr_block_default_b,
@@ -22,9 +22,9 @@ public_cidr_block = "{{ public_cidr_block | default(public_cidr_block_defaults) 
   openregister_cidr_block_default_c 
   ] | join(' ') -%}
 openregister_cidr_block = "{{ openregister_cidr_block | default(openregister_cidr_block_defaults) }}"
-{% set openregister_database_cidr_block_default_a = vpc_cidr_block | ipsubnet(27, 160) -%}
-{% set openregister_database_cidr_block_default_b = vpc_cidr_block | ipsubnet(27, 161) -%}
-{% set openregister_database_cidr_block_default_c = vpc_cidr_block | ipsubnet(27, 162) -%}
+{% set openregister_database_cidr_block_default_a = vpc_cidr_block | ipsubnet(24, 24) -%}
+{% set openregister_database_cidr_block_default_b = vpc_cidr_block | ipsubnet(24, 25) -%}
+{% set openregister_database_cidr_block_default_c = vpc_cidr_block | ipsubnet(24, 26) -%}
 {% set openregister_database_cidr_block_defaults = [
   openregister_database_cidr_block_default_a, 
   openregister_database_cidr_block_default_b, 


### PR DESCRIPTION
When we generate the .tfvars file for a new environment, we create quite
a few /27 subnets (address space size: 32).  This has caused problems in
the past, in particular because ELBs use a surprisingly large number of
addresses and don't want to be put into a subnet with fewer than 10 free
addresses.

I've upped all subnets to be /24-sized (address space size of 256).
It's hard to understand the ipsubnet() function so I did a test run on
the 192.0.0.0/16 block.  Beforehand we allocated these subnets:

   - public cidr blocks:
     - 192.0.10.0/27
     - 192.0.10.32/27
     - 192.0.10.64/27
   - openregister cidr blocks:
     - 192.0.21.0/24
     - 192.0.22.0/24
     - 192.0.23.0/24
   - openregister db cidr blocks:
     - 192.0.20.0/27
     - 192.0.20.32/27
     - 192.0.20.64/27

After this change, we allocate these subnets instead:

   - public cidr blocks:
     - 192.0.1.0/24
     - 192.0.2.0/24
     - 192.0.3.0/24
   - openregister cidr blocks:
     - 192.0.21.0/24
     - 192.0.22.0/24
     - 192.0.23.0/24
   - openregister db cidr blocks:
     - 192.0.24.0/24
     - 192.0.25.0/24
     - 192.0.26.0/24

I tried to avoid reusing the same IPs in old-form vs new-form subnets.