### PR TITLE
Change ansible scripts to configure register history urls

### DIFF
--- a/ansible/group_vars/tag_Environment_alpha
+++ b/ansible/group_vars/tag_Environment_alpha
@@ -21,3 +21,7 @@ register_domain: alpha.openregister.org
 register_settings:
   address:
     enable_download_resource: false
+  local-authority-eng:
+    history_page_url: https://registers-history.herokuapp.com/local-authority-eng
+  territory:
+    history_page_url: https://registers-history.herokuapp.com/territory

--- a/ansible/group_vars/tag_Environment_beta
+++ b/ansible/group_vars/tag_Environment_beta
@@ -4,3 +4,7 @@ registers:
   - datatype
   - field
   - register
+
+register_settings:
+  country:
+    history_page_url: https://registers-history.herokuapp.com/country

--- a/ansible/roles/openregister_config/templates/openregister-config.yaml.j2
+++ b/ansible/roles/openregister_config/templates/openregister-config.yaml.j2
@@ -24,3 +24,5 @@ enableDownloadResource: {{ settings.enable_download_resource | default(true) }}
 credentials:
   user: {{ app_user }}
   password: {{ app_password }}
+
+{% if settings.history_page_url is defined %}historyPageUrl: {{ settings.history_page_url }}{% endif %}


### PR DESCRIPTION
Add register history URLs as variables to thetag_Environment_xxx files. If the variable does not exist for the register, do not include in the template for creating config.yaml.