### PR TITLE
Add parameter to allow use of .ssh/config when deploying data

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,3 +273,11 @@ Or finally, import all registers defined for selected environment:
 	ansible-playbook mint_data.yml \
 		-e vpc=<name> \
 		-e @group_vars/tag_Environment_alpha
+
+If your remote username is different (set in `.ssh/config`) you can set additional parameter `use_local_username` to false forcing ansible to use `.ssh/config`:
+
+	cd ansible
+	ansible-playbook mint_data.yml \
+		-e vpc=<name> \
+		-e registers=<name> \
+		-e use_local_username=false

--- a/ansible/mint_data.yml
+++ b/ansible/mint_data.yml
@@ -26,6 +26,8 @@
 
 - name: Load data
   hosts: collected_hosts
+  vars:
+    set_remote_user: "{{ use_local_username|default(True)|bool }}"
   vars_files:
     - 'roles/service_data/vars/data-sources.yml'
   roles:

--- a/ansible/roles/service_data/tasks/data.yml
+++ b/ansible/roles/service_data/tasks/data.yml
@@ -2,5 +2,5 @@
   file: state=directory dest="{{ workdir }}"
 
 - name: Upload data files
-  synchronize: src="{{ src_data }}" dest="{{ workdir }}/"
+  synchronize: src="{{ src_data }}" dest="{{ workdir }}/" set_remote_user={{ set_remote_user }}
   delegate_to: 127.0.0.1


### PR DESCRIPTION
it works but the name `use_local_username` can be more expressive though, any thoughts?