### PR TITLE
Use AWS Managed NAT Gateway

### DIFF
--- a/aws/modules/core/gateways.tf
+++ b/aws/modules/core/gateways.tf
@@ -6,10 +6,3 @@ resource "aws_internet_gateway" "igw" {
     Environment = "${var.vpc_name}"
   }
 }
-
-/*
-resource "aws_nat_gateway" "natgw" {
-  allocation_id = "${aws_eip.nat.id}"
-  subnet_id = "${element(aws_subnet.public.*.id, count.index)}"
-}
-*/

--- a/aws/modules/core/nat_instance.tf
+++ b/aws/modules/core/nat_instance.tf
@@ -13,3 +13,16 @@ resource "aws_instance" "natgw" {
     Role = "nat-gateway"
   }
 }
+
+resource "aws_eip" "nat_ip" { }
+
+resource "aws_nat_gateway" "natgw" {
+  allocation_id = "${aws_eip.nat_ip.id}"
+  subnet_id = "${aws_subnet.public.0.id}"
+
+  // It's recommended to denote that the NAT Gateway depends on the Internet
+  // Gateway for the VPC in which the NAT Gateway's subnet is located.
+  //
+  // https://www.terraform.io/docs/providers/aws/r/nat_gateway.html
+  depends_on = ["aws_internet_gateway.igw"]
+}

--- a/aws/modules/core/subnets.tf
+++ b/aws/modules/core/subnets.tf
@@ -36,7 +36,7 @@ resource "aws_route_table" "private" {
 
   route = {
     cidr_block = "0.0.0.0/0"
-    instance_id = "${aws_instance.natgw.id}"
+    nat_gateway_id = "${aws_nat_gateway.natgw.id}"
   }
 
   tags = {


### PR DESCRIPTION
Deploying this change will mean instances in private subnets will use the [AWS Managed NAT Gateway](https://aws.amazon.com/blogs/aws/new-managed-nat-network-address-translation-gateway-for-aws/) to route traffic outbound.

We still need to tidy up the exisiting NAT instances so that they doen't have two roles (Bastion and NAT Gateway), but it seems sensible to do these as two separate deploys.