### PR TITLE
Pin terraform version

### DIFF
--- a/aws/registers/Makefile
+++ b/aws/registers/Makefile
@@ -29,7 +29,6 @@ module_depth=-1
 check-for-local-state: 
 	@test ! -f terraform.tfstate || exit 1
 
-check-variables:
 ifndef vpc
   $(error You must pass -e vpc=<name> switch)
 endif
@@ -42,7 +41,7 @@ endif
 purge-remote-state-cache: 
 	rm -rf .terraform/terraform.tfstate
 
-configure-state: check-variables check-for-local-state purge-remote-state-cache
+configure-state: check-for-local-state purge-remote-state-cache
 	terraform remote config \
           -backend=S3 \
           -backend-config="bucket=registers-terraform-state" \

--- a/aws/registers/Makefile
+++ b/aws/registers/Makefile
@@ -15,7 +15,7 @@
 export expected_terraform_version=v0.7.8
 export actual_terraform_version=$(shell terraform version | head -n 1 | cut -f2 -d" ")
 
-ifneq (expected_terraform_version, actual_terraform_version)
+ifneq ($(expected_terraform_version), $(actual_terraform_version))
   $(error Expected terraform version $(expected_terraform_version), but saw $(actual_terraform_version))
 endif
 

--- a/aws/registers/Makefile
+++ b/aws/registers/Makefile
@@ -12,6 +12,17 @@
 	push-config \
 	push-state
 
+export expected_terraform_version=v0.7.8
+export actual_terraform_version=$(shell terraform version | head -n 1 | cut -f2 -d" ")
+
+ifneq (expected_terraform_version, actual_terraform_version)
+  $(error Expected terraform version $(expected_terraform_version), but saw $(actual_terraform_version))
+endif
+
+ifndef vpc
+  $(error You must pass -e vpc=<name> switch)
+endif
+
 # Default AWS region
 export AWS_DEFAULT_REGION=eu-west-1
 
@@ -28,10 +39,6 @@ module_depth=-1
 # configured, so refuse to run if it exists.
 check-for-local-state: 
 	@test ! -f terraform.tfstate || exit 1
-
-ifndef vpc
-  $(error You must pass -e vpc=<name> switch)
-endif
 
 # TODO should also reject defined-but-blank variable
 ifndef TF_VAR_openregister_database_master_password


### PR DESCRIPTION
This sets an expected terraform version in the Makefile and runs a check
to ensure that we are running the expected version of terraform.  This
is to avoid inadvertantly running a newer version of terraform and thus
migrating the statefile to a non-backward-compatible version.