### PR TITLE
Fix bug where the same data got minted multiple times

### DIFF
--- a/ansible/mint_data.yml
+++ b/ansible/mint_data.yml
@@ -25,7 +25,7 @@
       always_run: yes
 
 - name: Load data
-  hosts: collected_hosts
+  hosts: "collected_hosts[0]"
   vars:
     set_remote_user: "{{ use_local_username|default(True)|bool }}"
   vars_files:


### PR DESCRIPTION
The mint_data.yml playbook had a problem when minting to a register
which had multiple app servers: it would run the minting task once per
appserver, rather than once.  This meant that you would get as many
copies of data as you had appservers.

This fixes the problem by selecting the first appserver in the
`collected_hosts` group, rather than the whole group.