### PR TITLE
Create hosted private DNS zone for VPCs

### DIFF
--- a/ansible/roles/terraform_config/templates/register_template.tf.j2
+++ b/ansible/roles/terraform_config/templates/register_template.tf.j2
@@ -14,6 +14,7 @@ module "{{ item }}_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/modules/core/outputs.tf
+++ b/aws/modules/core/outputs.tf
@@ -44,3 +44,7 @@ output "public_subnet_ids" {
 output "dns_zone_id" {
   value = "${aws_route53_zone.core.zone_id}"
 }
+
+output "private_dns_zone_id" {
+  value = "${aws_route53_zone.private.zone_id}"
+}

--- a/aws/modules/core/route53.tf
+++ b/aws/modules/core/route53.tf
@@ -17,3 +17,8 @@ resource "aws_route53_record" "zone_delegation" {
   ttl = "${var.dns_ttl}"
   records = [ "${aws_route53_zone.core.name_servers}" ]
 }
+
+resource "aws_route53_zone" "private" {
+  name = "${var.vpc_name}.openregister"
+  vpc_id = "${aws_vpc.registers.id}"
+}

--- a/aws/modules/instance/main.tf
+++ b/aws/modules/instance/main.tf
@@ -22,3 +22,12 @@ resource "aws_instance" "instance" {
     DeploymentGroup = "${var.vpc_name}-${var.role}"
   }
 }
+
+resource "aws_route53_record" "instance_record" {
+  count = "${var.instance_count}"
+  zone_id = "${var.private_dns_zone_id}"
+  name = "${var.id}-${count.index + 1}"
+  type = "A"
+  ttl = "300"
+  records = [ "${element(aws_instance.instance.*.private_ip, count.index)}" ]
+}

--- a/aws/modules/instance/variables.tf
+++ b/aws/modules/instance/variables.tf
@@ -31,3 +31,5 @@ variable "user_data" {}
 variable "subnet_ids" { type = "list" }
 
 variable "security_group_ids" { type = "list" }
+
+variable "private_dns_zone_id" {}

--- a/aws/registers/register_address.tf
+++ b/aws/registers/register_address.tf
@@ -14,6 +14,7 @@ module "address_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_company.tf
+++ b/aws/registers/register_company.tf
@@ -14,6 +14,7 @@ module "company_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_country.tf
+++ b/aws/registers/register_country.tf
@@ -14,6 +14,7 @@ module "country_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_datatype.tf
+++ b/aws/registers/register_datatype.tf
@@ -14,6 +14,7 @@ module "datatype_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_denomination.tf
+++ b/aws/registers/register_denomination.tf
@@ -14,6 +14,7 @@ module "denomination_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_diocese.tf
+++ b/aws/registers/register_diocese.tf
@@ -14,6 +14,7 @@ module "diocese_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_field.tf
+++ b/aws/registers/register_field.tf
@@ -14,6 +14,7 @@ module "field_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_food_authority.tf
+++ b/aws/registers/register_food_authority.tf
@@ -14,6 +14,7 @@ module "food-authority_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_food_premises.tf
+++ b/aws/registers/register_food_premises.tf
@@ -14,6 +14,7 @@ module "food-premises_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_food_premises_rating.tf
+++ b/aws/registers/register_food_premises_rating.tf
@@ -14,6 +14,7 @@ module "food-premises-rating_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_food_premises_type.tf
+++ b/aws/registers/register_food_premises_type.tf
@@ -14,6 +14,7 @@ module "food-premises-type_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_government_domain.tf
+++ b/aws/registers/register_government_domain.tf
@@ -14,6 +14,7 @@ module "government-domain_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_industry.tf
+++ b/aws/registers/register_industry.tf
@@ -14,6 +14,7 @@ module "industry_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_job_centre.tf
+++ b/aws/registers/register_job_centre.tf
@@ -14,6 +14,7 @@ module "job-centre_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_local_authority.tf
+++ b/aws/registers/register_local_authority.tf
@@ -14,6 +14,7 @@ module "local-authority_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_local_authority_eng.tf
+++ b/aws/registers/register_local_authority_eng.tf
@@ -14,6 +14,7 @@ module "local-authority-eng_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_local_authority_nir.tf
+++ b/aws/registers/register_local_authority_nir.tf
@@ -14,6 +14,7 @@ module "local-authority-nir_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_local_authority_sct.tf
+++ b/aws/registers/register_local_authority_sct.tf
@@ -14,6 +14,7 @@ module "local-authority-sct_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_local_authority_type.tf
+++ b/aws/registers/register_local_authority_type.tf
@@ -14,6 +14,7 @@ module "local-authority-type_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_local_authority_wls.tf
+++ b/aws/registers/register_local_authority_wls.tf
@@ -14,6 +14,7 @@ module "local-authority-wls_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_place.tf
+++ b/aws/registers/register_place.tf
@@ -14,6 +14,7 @@ module "place_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_premises.tf
+++ b/aws/registers/register_premises.tf
@@ -14,6 +14,7 @@ module "premises_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_register.tf
+++ b/aws/registers/register_register.tf
@@ -14,6 +14,7 @@ module "register_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_religious_character.tf
+++ b/aws/registers/register_religious_character.tf
@@ -14,6 +14,7 @@ module "religious-character_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_school.tf
+++ b/aws/registers/register_school.tf
@@ -14,6 +14,7 @@ module "school_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_school_admissions_policy.tf
+++ b/aws/registers/register_school_admissions_policy.tf
@@ -14,6 +14,7 @@ module "school-admissions-policy_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_school_authority.tf
+++ b/aws/registers/register_school_authority.tf
@@ -14,6 +14,7 @@ module "school-authority_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_school_authority_eng.tf
+++ b/aws/registers/register_school_authority_eng.tf
@@ -14,6 +14,7 @@ module "school-authority-eng_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_school_eng.tf
+++ b/aws/registers/register_school_eng.tf
@@ -14,6 +14,7 @@ module "school-eng_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_school_federation.tf
+++ b/aws/registers/register_school_federation.tf
@@ -14,6 +14,7 @@ module "school-federation_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_school_gender.tf
+++ b/aws/registers/register_school_gender.tf
@@ -14,6 +14,7 @@ module "school-gender_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_school_phase.tf
+++ b/aws/registers/register_school_phase.tf
@@ -14,6 +14,7 @@ module "school-phase_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_school_tag.tf
+++ b/aws/registers/register_school_tag.tf
@@ -14,6 +14,7 @@ module "school-tag_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_school_trust.tf
+++ b/aws/registers/register_school_trust.tf
@@ -14,6 +14,7 @@ module "school-trust_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_school_type.tf
+++ b/aws/registers/register_school_type.tf
@@ -14,6 +14,7 @@ module "school-type_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_street.tf
+++ b/aws/registers/register_street.tf
@@ -14,6 +14,7 @@ module "street_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_territory.tf
+++ b/aws/registers/register_territory.tf
@@ -14,6 +14,7 @@ module "territory_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]

--- a/aws/registers/register_uk.tf
+++ b/aws/registers/register_uk.tf
@@ -14,6 +14,7 @@ module "uk_openregister" {
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"
+  private_dns_zone_id = "${module.core.private_dns_zone_id}"
 
   subnet_ids = "${module.openregister.subnet_ids}"
   security_group_ids = ["${module.openregister.security_group_id}"]


### PR DESCRIPTION
This creates a hosted private DNS zone to give names to our internal
instances.

The idea is that you can add *.<vpc-name>.openregister to your ssh config and
route via the bastion host; you then use DNS resolution on the bastion
host to resolve the internal name to its private IP.