### PR TITLE
Simplify ansible host selection in mint_data.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,22 +260,12 @@ Then run the playbook:
     	-e vpc=<name> \
     	-e registers=<name>
     
-Alternatively, you can provide specify an array of registers to load:
+Alternatively, you can provide specify an array of registers to load by passing a JSON array to the `registers` variable:
 
-`cat registers-to-load.yaml`
+    ansible-playbook mint_data.yml \
+    	-e vpc=<name> \
+    	-e registers='["country","territory","uk"]'
 
-	registers:
-	  - country
-	  - territory
-	  - uk
-
-And then run:
-
-	cd ansible
-	ansible-playbook mint_data.yml \
-		-e vpc=<name> \
-		-e @registers-to-load.yaml
-	
 Or finally, import all registers defined for selected environment:
 
 	cd ansible

--- a/ansible/ec2.ini
+++ b/ansible/ec2.ini
@@ -39,7 +39,7 @@ vpc_destination_variable = private_ip_address
 
 # To tag instances on EC2 with the resource records that point to them from
 # Route53, uncomment and set 'route53' to True.
-route53 = False
+route53 = True
 
 # To exclude RDS instances from the inventory, uncomment and set to False.
 rds = True

--- a/ansible/mint_data.yml
+++ b/ansible/mint_data.yml
@@ -8,24 +8,8 @@
       when: registers is none
       always_run: yes
 
-- name: Compute mint hosts
-  hosts: localhost
-  vars:
-    vpc_tag: 'tag_Environment_{{ vpc }}'
-  tasks:
-    - name: query openregister hosts
-      set_fact:
-        openregister_hosts: "{{ groups.tag_Role_openregister_app | intersect(groups[vpc_tag]) }}"
-      always_run: yes
-
-    - name: include matching hosts
-      add_host: name="{{ item }}" group="collected_hosts"
-      with_items: "{{ openregister_hosts }}"
-      when: hostvars[item].ec2_tag_Register == registers
-      always_run: yes
-
 - name: Load data
-  hosts: "collected_hosts[0]"
+  hosts: "{{ registers }}-1.{{ vpc }}.openregister"
   vars:
     set_remote_user: "{{ use_local_username|default(True)|bool }}"
   vars_files:

--- a/ansible/mint_data.yml
+++ b/ansible/mint_data.yml
@@ -8,8 +8,18 @@
       when: registers is none
       always_run: yes
 
+- name: Compute mint hosts
+  hosts: localhost
+  vars:
+    vpc_tag: 'tag_Environment_{{ vpc }}'
+  tasks:
+    - name: include matching hosts
+      add_host: name="{{ item }}-1.{{ vpc }}.openregister" group="hosts_to_mint" register="{{ item }}"
+      with_items: "{{ registers }}"
+      always_run: yes
+
 - name: Load data
-  hosts: "{{ registers }}-1.{{ vpc }}.openregister"
+  hosts: "hosts_to_mint"
   vars:
     set_remote_user: "{{ use_local_username|default(True)|bool }}"
   vars_files:

--- a/ansible/roles/service_data/tasks/facts.yml
+++ b/ansible/roles/service_data/tasks/facts.yml
@@ -1,5 +1,5 @@
 - set_fact:
-    id: "{{ hostvars[inventory_hostname]['ec2_tag_Register'] }}"
+    id: "{{ hostvars[inventory_hostname]['register'] }}"
 
 - set_fact:
     src_data: "{{ sources[id]['src_data'] }}"


### PR DESCRIPTION
This adds our shiny new route53 private hosted zones to our ansible
inventory.  This means we have groups for each instance corresponding to
the route53 record name.  For example, there's a group called
`country-1.test.openregister` which contains one host, the first
appserver for the country register in the test vpc.

We can now use these names to more easily identify a single appserver
for a register within a VPC in mint_data.yaml.