### PR TITLE
Remove `push-state` task

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,12 +189,11 @@ Skip this if you have not created any new `.tf` or `.tfvars` files.
 
 ### Pushing local changes to terraform config
 
-The terraform config and state files for each environment are not stored in Git but are
-stored in S3. Any local changes made and applied should be pushed back to S3.
+The terraform config file for each environment is not stored in Git but is
+stored in S3. Any local changes made and applied should be pushed back to S3:
 
 	cd aws/registers
 	make push-config -e vpc=<name>
-	make push-state -e vpc=<name>
 
 # Running the registers application
 

--- a/aws/registers/Makefile
+++ b/aws/registers/Makefile
@@ -71,9 +71,6 @@ remove-bucket:
 remove-state:
 	aws s3 rm s3://registers-terraform-state/$(vpc).tfstate
 
-push-state:
-	terraform remote push
-
 plan: configure-state
 	terraform plan $(defaults) -module-depth=$(module_depth)
 


### PR DESCRIPTION
It shouldn't be the case that pushing remote state should be done manually. Running a `terraform apply` will update the remote state.