### PR TITLE
Redirect job-centre to jobcentre

### DIFF
--- a/aws/modules/redirect/main.tf
+++ b/aws/modules/redirect/main.tf
@@ -1,0 +1,65 @@
+resource "aws_s3_bucket" "s3_redirect" {
+  count = "${var.enabled}"
+  bucket = "${var.from}"
+  acl = "public-read"
+
+  website {
+    redirect_all_requests_to = "${var.to}"
+  }
+}
+
+resource "aws_cloudfront_distribution" "cf_redirect" {
+  count = "${var.enabled}"
+  origin {
+    domain_name = "${aws_s3_bucket.s3_redirect.id}.s3.amazonaws.com"
+    origin_id   = "${var.from}"
+
+    # s3_origin_config {
+    #   # origin_access_identity = "origin-access-identity/cloudfront/ABCDEFG1234567"
+    # }
+  }
+
+  default_cache_behavior {
+    allowed_methods = ["GET", "HEAD"]
+    cached_methods = ["GET", "HEAD"]
+    default_ttl = 300
+    forwarded_values {
+      cookies {
+        forward = "none"
+      }
+      query_string = true
+    }
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl = 300
+    max_ttl = 300
+    target_origin_id = "${var.from}"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn = "${var.certificate_arn}"
+    ssl_support_method = "sni-only"
+    minimum_protocol_version = "TLSv1"
+  }
+
+  aliases = ["${var.from}"]
+  enabled = "${var.enabled}"
+}
+
+resource "aws_route53_record" "r53_redirect" {
+  count = "${var.enabled}"
+  zone_id = "${var.dns_zone_id}"
+  name = "${var.from}"
+  type = "A"
+
+  alias {
+    name = "${aws_cloudfront_distribution.cf_redirect.domain_name}"
+    zone_id = "${aws_cloudfront_distribution.cf_redirect.hosted_zone_id}"
+    evaluate_target_health = false
+  }
+}

--- a/aws/modules/redirect/main.tf
+++ b/aws/modules/redirect/main.tf
@@ -13,10 +13,6 @@ resource "aws_cloudfront_distribution" "cf_redirect" {
   origin {
     domain_name = "${aws_s3_bucket.s3_redirect.id}.s3.amazonaws.com"
     origin_id   = "${var.from}"
-
-    # s3_origin_config {
-    #   # origin_access_identity = "origin-access-identity/cloudfront/ABCDEFG1234567"
-    # }
   }
 
   default_cache_behavior {

--- a/aws/modules/redirect/variables.tf
+++ b/aws/modules/redirect/variables.tf
@@ -1,0 +1,5 @@
+variable "from" {}
+variable "to" {}
+variable "certificate_arn" {}
+variable "dns_zone_id" {}
+variable "enabled" {}

--- a/aws/registers/register_job_centre.tf
+++ b/aws/registers/register_job_centre.tf
@@ -1,42 +1,10 @@
-module "job-centre_policy" {
-  source = "../modules/instance_policy"
-  id = "job-centre"
+module "job-centre_redirect" {
+  source = "../modules/redirect"
+
   enabled = "${signum(lookup(var.instance_count, "job-centre"))}"
 
-  vpc_name = "${var.vpc_name}"
-  vpc_id = "${module.core.vpc_id}"
-}
-
-module "job-centre_openregister" {
-  source = "../modules/instance"
-  id = "job-centre"
-  role = "openregister_app"
-
-  vpc_name = "${var.vpc_name}"
-  vpc_id = "${module.core.vpc_id}"
-  private_dns_zone_id = "${module.core.private_dns_zone_id}"
-
-  subnet_ids = "${module.openregister.subnet_ids}"
-  security_group_ids = ["${module.openregister.security_group_id}"]
-
-  instance_count = "${lookup(var.instance_count, "job-centre")}"
-  iam_instance_profile = "${module.job-centre_policy.profile_name}"
-
-  user_data = "${data.template_file.user_data.rendered}"
-}
-
-module "job-centre_elb" {
-  source = "../modules/load_balancer"
-  id = "job-centre"
-  enabled = "${signum(lookup(var.instance_count, "job-centre"))}"
-
-  vpc_name = "${var.vpc_name}"
-  vpc_id = "${module.core.vpc_id}"
-
-  instance_ids = "${module.job-centre_openregister.instance_ids}"
-  security_group_ids = ["${module.openregister.security_group_id}"]
-  subnet_ids = "${module.core.public_subnet_ids}"
-
+  from = "job-centre.${var.vpc_name}.openregister.org"
+  to   = "jobcentre.${var.vpc_name}.openregister.org"
+  certificate_arn = "${var.cloudfront_certificate_arn}"
   dns_zone_id = "${module.core.dns_zone_id}"
-  certificate_arn = "${var.elb_certificate_arn}"
 }

--- a/aws/registers/variables.tf
+++ b/aws/registers/variables.tf
@@ -139,3 +139,4 @@ variable "codedeploy_service_role_arn" {
 
 // https
 variable "elb_certificate_arn" {}
+variable "cloudfront_certificate_arn" {}


### PR DESCRIPTION
This adds a new module, `redirect`, which allows you to redirect all
requests from one domain to another.  It's built from an S3 static
website (which does the actual redirecting), a CloudFront
distribution (which is just there to support HTTPS) and a Route 53
record.

It also instantiates the module for the job-centre discovery register,
redirecting to the jobcentre register instead.