### PR TITLE
move route 53 record out of module/register temporarily

### DIFF
--- a/aws/modules/register/elb.tf
+++ b/aws/modules/register/elb.tf
@@ -66,11 +66,13 @@ resource "aws_security_group" "load_balancer" {
   }
 }
 
-resource "aws_route53_record" "load_balancer" {
-  count = "${signum(var.instance_count)}"
-  zone_id = "${var.dns_zone_id}"
-  name = "${var.id}.${var.vpc_name}.${var.dns_domain}"
-  type = "CNAME"
-  ttl = "${var.dns_ttl}"
-  records = [ "${aws_elb.load_balancer.dns_name}" ]
-}
+# FIXME: disabled while we migrate everything over
+#
+# resource "aws_route53_record" "load_balancer" {
+#   count = "${signum(var.instance_count)}"
+#   zone_id = "${var.dns_zone_id}"
+#   name = "${var.id}.${var.vpc_name}.${var.dns_domain}"
+#   type = "CNAME"
+#   ttl = "${var.dns_ttl}"
+#   records = [ "${aws_elb.load_balancer.dns_name}" ]
+# }

--- a/aws/modules/register/outputs.tf
+++ b/aws/modules/register/outputs.tf
@@ -1,0 +1,3 @@
+output "elb_dns_name" {
+  value = "${aws_elb.load_balancer.dns_name}"
+}

--- a/aws/registers/register_diocese.tf
+++ b/aws/registers/register_diocese.tf
@@ -14,3 +14,12 @@ module "diocese" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 }
+
+resource "aws_route53_record" "load_balancer" {
+  count = "${signum(lookup(var.instance_count, "diocese"))}"
+  zone_id = "${module.core.private_dns_zone_id}"
+  name = "diocese.${var.vpc_name}.openregister.org"
+  type = "CNAME"
+  ttl = "300"
+  records = [ "${module.diocese.elb_dns_name}" ]
+}


### PR DESCRIPTION
While we're migrating registers from the old modules to the new module,
we should handle the route 53 record separately.  This will allow us to
create new registers, deploy the app to them, ensure they're working,
and finally flip the route 53 record from the old to the new, before
destroying the old infrastructure.