### PR TITLE
Makefile: fail if we can't get required creds

### DIFF
--- a/aws/registers/Makefile
+++ b/aws/registers/Makefile
@@ -27,7 +27,7 @@ endif
 export AWS_DEFAULT_REGION=eu-west-1
 
 # RDS master passwords
-export TF_VAR_openregister_database_master_password=$(shell PASSWORD_STORE_DIR=~/.registers-pass pass $(vpc)/rds/openregister/master)
+export TF_VAR_openregister_database_master_password=$(or $(shell PASSWORD_STORE_DIR=~/.registers-pass pass $(vpc)/rds/openregister/master), $(error "Couldn't get RDS master password from pass"))
 
 # Required minimum to terraform
 defaults=-var-file=environments/$(vpc).tfvars


### PR DESCRIPTION
This causes the Makefile to fail completely with an error if the call to
`pass` fails.  Before, it would just return an empty string and carry on
merrily with all of the terraform processing.