### PR TITLE
Increase the size of the Food Premises Rating instances

### DIFF
--- a/aws/registers/register_food_premises_rating.tf
+++ b/aws/registers/register_food_premises_rating.tf
@@ -2,6 +2,7 @@ module "food-premises-rating" {
   source = "../modules/register"
   id = "food-premises-rating"
   instance_count = "${lookup(var.instance_count, "food-premises-rating")}"
+  instance_type = "t2.small"
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"


### PR DESCRIPTION
We need more RAM for this register--`t2.small` gives us 2GB compared to the 1GB on `t2.micro`.