### PR TITLE
Enable CloudTrail

### DIFF
--- a/aws/cloudtrail/Makefile
+++ b/aws/cloudtrail/Makefile
@@ -1,0 +1,41 @@
+.PHONY: all \
+	check-for-local-state \
+	configure-state \
+	destroy \
+	plan \
+	plan-destroy
+
+export expected_terraform_version=v0.7.13
+export actual_terraform_version=$(shell terraform version | head -n 1 | cut -f2 -d" ")
+
+ifneq ($(expected_terraform_version), $(actual_terraform_version))
+	$(error Expected terraform version $(expected_terraform_version), but saw $(actual_terraform_version))
+endif
+
+# Default terraform plan -module-depth= value
+module_depth=-1
+
+# We don't want any local state being pushed when remote state is
+# configured, so refuse to run if it exists.
+check-for-local-state:
+	@test ! -f terraform.tfstate || true
+
+configure-state: check-for-local-state
+	terraform remote config \
+          -backend=S3 \
+          -backend-config="bucket=registers-cloudtrail-terraform-state" \
+          -backend-config="encrypt=true" \
+          -backend-config="key=cloudtrail.tfstate" \
+          -backend-config="region=eu-west-1"
+
+plan: configure-state
+	terraform plan -module-depth=$(module_depth)
+
+plan-destroy: configure-state
+	terraform plan -destroy -module-depth=$(module_depth)
+
+apply: configure-state
+	terraform apply
+
+destroy: configure-state
+	terraform destroy

--- a/aws/cloudtrail/README.md
+++ b/aws/cloudtrail/README.md
@@ -1,0 +1,18 @@
+# Terraform configuration for CloudTrail
+
+## Prerequisites
+
+You'll [Terraform](https://www.terraform.io/). You should install Terraform using the method described [here](https://github.com/openregister/deployment/blob/master/README.md#prerequisites).
+
+Fetch external Terraform modules:
+
+  terraform get
+
+Run a plan:
+
+  make plan
+
+Review and apply changes:
+
+  make apply
+

--- a/aws/cloudtrail/main.tf
+++ b/aws/cloudtrail/main.tf
@@ -1,0 +1,30 @@
+provider "aws" {
+  region = "eu-west-1"
+}
+
+module "aws-security-alarms" {
+  source                      = "github.com/alphagov/aws-security-alarms//terraform"
+  cloudtrail_s3_bucket_name   = "cloudtrail-logs-openregister"
+  cloudtrail_s3_bucket_prefix = "prod"
+}
+
+module "unexpected-ip-access" {
+  source               = "github.com/alphagov/aws-security-alarms//terraform/alarms/unexpected_ip_access"
+  environment_name     = "test"
+  cloudtrail_log_group = "${module.aws-security-alarms.cloudtrail_log_group}"
+  alarm_actions        = ["${module.aws-security-alarms.security-alerts-topic}"]
+}
+
+module "unauthorized-activity" {
+  source               = "github.com/alphagov/aws-security-alarms//terraform/alarms/unauthorized_activity"
+  environment_name     = "test"
+  cloudtrail_log_group = "${module.aws-security-alarms.cloudtrail_log_group}"
+  alarm_actions        = ["${module.aws-security-alarms.security-alerts-topic}"]
+}
+
+module "root-activity" {
+  source               = "github.com/alphagov/aws-security-alarms//terraform/alarms/root_activity"
+  environment_name     = "test"
+  cloudtrail_log_group = "${module.aws-security-alarms.cloudtrail_log_group}"
+  alarm_actions        = ["${module.aws-security-alarms.security-alerts-topic}"]
+}


### PR DESCRIPTION
This enables CloudTrail logging from all regions to a single bucket.

The Terraform code to enable CloudTrail comes from a repo that David
King has been working on. We've been playing with CloudWatch Alarms that
are triggered from CloudTrail logs to see if we can usefully alert on
potential security issues. At the moment we're not sure if these will be
useful (as we haven't tested them with CloudTrail logs from a "real"
account), which is why all the alarm names are currently prefixed with
"test".