### PR TITLE
Update `aws-security-alarms` module

### DIFF
--- a/aws/cloudtrail/main.tf
+++ b/aws/cloudtrail/main.tf
@@ -12,19 +12,19 @@ module "unexpected-ip-access" {
   source               = "github.com/alphagov/aws-security-alarms//terraform/alarms/unexpected_ip_access"
   environment_name     = "test"
   cloudtrail_log_group = "${module.aws-security-alarms.cloudtrail_log_group}"
-  alarm_actions        = ["${module.aws-security-alarms.security-alerts-topic}"]
+  alarm_actions        = ["${module.aws-security-alarms.security_alerts_topic}"]
 }
 
 module "unauthorized-activity" {
   source               = "github.com/alphagov/aws-security-alarms//terraform/alarms/unauthorized_activity"
   environment_name     = "test"
   cloudtrail_log_group = "${module.aws-security-alarms.cloudtrail_log_group}"
-  alarm_actions        = ["${module.aws-security-alarms.security-alerts-topic}"]
+  alarm_actions        = ["${module.aws-security-alarms.security_alerts_topic}"]
 }
 
 module "root-activity" {
   source               = "github.com/alphagov/aws-security-alarms//terraform/alarms/root_activity"
   environment_name     = "test"
   cloudtrail_log_group = "${module.aws-security-alarms.cloudtrail_log_group}"
-  alarm_actions        = ["${module.aws-security-alarms.security-alerts-topic}"]
+  alarm_actions        = ["${module.aws-security-alarms.security_alerts_topic}"]
 }


### PR DESCRIPTION
The upstream module has been updated to fix an issue with S3 bucket policy CloudTrail logs to.