### PR TITLE
Add queues and triggers for notifications from CodeDeploy

### DIFF
--- a/aws/modules/codedeploy_group/main.tf
+++ b/aws/modules/codedeploy_group/main.tf
@@ -1,3 +1,7 @@
+resource "aws_sns_topic" "deployments" {
+  name = "deployments-${var.id}"
+}
+
 resource "aws_codedeploy_deployment_group" "codedeploy_group" {
   deployment_group_name = "${var.id}"
   app_name = "${var.application}"
@@ -7,5 +11,11 @@ resource "aws_codedeploy_deployment_group" "codedeploy_group" {
     key = "DeploymentGroup"
     type = "KEY_AND_VALUE"
     value = "${var.tag}"
+  }
+
+  trigger_configuration {
+    trigger_events = ["DeploymentStart", "DeploymentFailure", "DeploymentSuccess"]
+    trigger_name = "Send to Slack"
+    trigger_target_arn = "${aws_sns_topic.deployments.arn}"
   }
 }


### PR DESCRIPTION
We need this so we can notify to our Slack channel every time we deploy. Currently we're still manually deploying the Lambda function that hits the Slack Webhook as well as the triggers to glue SNS and Lambda together.