### PR TITLE
Use Terraform for CloudFront configuration

### DIFF
--- a/ansible/roles/terraform_config/templates/register_template.tf.j2
+++ b/ansible/roles/terraform_config/templates/register_template.tf.j2
@@ -14,5 +14,6 @@ module "{{ item }}" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/modules/register/cdn.tf
+++ b/aws/modules/register/cdn.tf
@@ -1,0 +1,58 @@
+resource "aws_cloudfront_distribution" "cloudfront" {
+  count = "${signum(var.enable_cdn * var.instance_count)}"
+  enabled = true
+
+  aliases = ["${var.id}.register.gov.uk"]
+
+  http_version = "http1.1"
+
+  origin {
+    domain_name = "${aws_route53_record.load_balancer.fqdn}"
+    origin_id   = "register_origin"
+
+    custom_origin_config {
+      http_port = 80 # "required" but not used
+
+      https_port = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols = ["TLSv1.2"]
+    }
+  }
+
+  default_cache_behavior {
+    allowed_methods = ["GET", "HEAD"]
+    cached_methods = ["GET", "HEAD"]
+    default_ttl = 300
+
+    forwarded_values {
+      headers = ["Accept", "Host", "Origin"]
+
+      cookies {
+        forward = "none"
+      }
+      query_string = true
+    }
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl = 300
+    max_ttl = 300
+    target_origin_id = "register_origin"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  logging_config {
+    bucket = "cloudfront-logs-register-gov-uk.s3.amazonaws.com"
+    prefix = "${var.id}"
+    include_cookies = false
+  }
+
+  viewer_certificate {
+    iam_certificate_arn = "${var.cloudfront_certificate_arn}"
+    ssl_support_method = "sni-only"
+    minimum_protocol_version = "TLSv1"
+  }
+}

--- a/aws/modules/register/variables.tf
+++ b/aws/modules/register/variables.tf
@@ -64,7 +64,16 @@ variable "certificate_arn" {
   description = "ARN for TLS certificate for ELB"
 }
 
+variable "cloudfront_certificate_arn" {
+  default = ""
+  description = "ARN for TLS certificate for CloudFront"
+}
+
 variable "enable_availability_checks" {
   default = false
   description = "Whether to enable availability health checks for this register"
+}
+
+variable "enable_cdn" {
+  description = "Whether to front this register with a CDN"
 }

--- a/aws/registers/register_academy_school_eng.tf
+++ b/aws/registers/register_academy_school_eng.tf
@@ -14,5 +14,6 @@ module "academy-school-eng" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_address.tf
+++ b/aws/registers/register_address.tf
@@ -15,5 +15,6 @@ module "address" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_company.tf
+++ b/aws/registers/register_company.tf
@@ -14,5 +14,6 @@ module "company" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_country.tf
+++ b/aws/registers/register_country.tf
@@ -14,5 +14,8 @@ module "country" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
+  cloudfront_certificate_arn = "${var.cloudfront_certificate_arn}"
+
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_court.tf
+++ b/aws/registers/register_court.tf
@@ -14,5 +14,6 @@ module "court" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_datatype.tf
+++ b/aws/registers/register_datatype.tf
@@ -14,5 +14,8 @@ module "datatype" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
+  cloudfront_certificate_arn = "${var.cloudfront_certificate_arn}"
+
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_denomination.tf
+++ b/aws/registers/register_denomination.tf
@@ -14,5 +14,6 @@ module "denomination" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_dental_practice.tf
+++ b/aws/registers/register_dental_practice.tf
@@ -14,5 +14,6 @@ module "dental-practice" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_diocese.tf
+++ b/aws/registers/register_diocese.tf
@@ -14,5 +14,6 @@ module "diocese" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_field.tf
+++ b/aws/registers/register_field.tf
@@ -14,5 +14,8 @@ module "field" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
+  cloudfront_certificate_arn = "${var.cloudfront_certificate_arn}"
+
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_food_authority.tf
+++ b/aws/registers/register_food_authority.tf
@@ -14,5 +14,6 @@ module "food-authority" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_food_premises.tf
+++ b/aws/registers/register_food_premises.tf
@@ -14,5 +14,6 @@ module "food-premises" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_food_premises_rating.tf
+++ b/aws/registers/register_food_premises_rating.tf
@@ -15,5 +15,6 @@ module "food-premises-rating" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_food_premises_type.tf
+++ b/aws/registers/register_food_premises_type.tf
@@ -14,5 +14,6 @@ module "food-premises-type" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_government_domain.tf
+++ b/aws/registers/register_government_domain.tf
@@ -14,5 +14,6 @@ module "government-domain" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_government_organisation.tf
+++ b/aws/registers/register_government_organisation.tf
@@ -14,5 +14,6 @@ module "government-organisation" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_government_website.tf
+++ b/aws/registers/register_government_website.tf
@@ -14,5 +14,6 @@ module "government-website" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_gp_practice.tf
+++ b/aws/registers/register_gp_practice.tf
@@ -14,5 +14,6 @@ module "gp-practice" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_industry.tf
+++ b/aws/registers/register_industry.tf
@@ -14,5 +14,6 @@ module "industry" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_internal_drainage_board.tf
+++ b/aws/registers/register_internal_drainage_board.tf
@@ -14,5 +14,6 @@ module "internal-drainage-board" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_jobcentre.tf
+++ b/aws/registers/register_jobcentre.tf
@@ -14,5 +14,6 @@ module "jobcentre" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_la_maintained_school_eng.tf
+++ b/aws/registers/register_la_maintained_school_eng.tf
@@ -14,5 +14,6 @@ module "la-maintained-school-eng" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_local_authority.tf
+++ b/aws/registers/register_local_authority.tf
@@ -14,5 +14,6 @@ module "local-authority" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_local_authority_eng.tf
+++ b/aws/registers/register_local_authority_eng.tf
@@ -14,5 +14,8 @@ module "local-authority-eng" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
+  cloudfront_certificate_arn = "${var.cloudfront_certificate_arn}"
+
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_local_authority_nir.tf
+++ b/aws/registers/register_local_authority_nir.tf
@@ -14,5 +14,6 @@ module "local-authority-nir" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_local_authority_sct.tf
+++ b/aws/registers/register_local_authority_sct.tf
@@ -14,5 +14,6 @@ module "local-authority-sct" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_local_authority_type.tf
+++ b/aws/registers/register_local_authority_type.tf
@@ -14,5 +14,8 @@ module "local-authority-type" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
+  cloudfront_certificate_arn = "${var.cloudfront_certificate_arn}"
+
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_local_authority_wls.tf
+++ b/aws/registers/register_local_authority_wls.tf
@@ -14,5 +14,6 @@ module "local-authority-wls" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_place.tf
+++ b/aws/registers/register_place.tf
@@ -14,5 +14,6 @@ module "place" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_police_force.tf
+++ b/aws/registers/register_police_force.tf
@@ -14,5 +14,6 @@ module "police-force" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_premises.tf
+++ b/aws/registers/register_premises.tf
@@ -14,5 +14,6 @@ module "premises" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_prison.tf
+++ b/aws/registers/register_prison.tf
@@ -14,5 +14,6 @@ module "prison" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_register.tf
+++ b/aws/registers/register_register.tf
@@ -14,5 +14,8 @@ module "register" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
+  cloudfront_certificate_arn = "${var.cloudfront_certificate_arn}"
+
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_register_office.tf
+++ b/aws/registers/register_register_office.tf
@@ -14,5 +14,6 @@ module "register-office" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_religious_character.tf
+++ b/aws/registers/register_religious_character.tf
@@ -14,5 +14,6 @@ module "religious-character" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_school.tf
+++ b/aws/registers/register_school.tf
@@ -14,5 +14,6 @@ module "school" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_school_admissions_policy.tf
+++ b/aws/registers/register_school_admissions_policy.tf
@@ -14,5 +14,6 @@ module "school-admissions-policy" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_school_authority.tf
+++ b/aws/registers/register_school_authority.tf
@@ -14,5 +14,6 @@ module "school-authority" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_school_authority_eng.tf
+++ b/aws/registers/register_school_authority_eng.tf
@@ -14,5 +14,6 @@ module "school-authority-eng" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_school_eng.tf
+++ b/aws/registers/register_school_eng.tf
@@ -14,5 +14,6 @@ module "school-eng" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_school_federation.tf
+++ b/aws/registers/register_school_federation.tf
@@ -14,5 +14,6 @@ module "school-federation" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_school_gender.tf
+++ b/aws/registers/register_school_gender.tf
@@ -14,5 +14,6 @@ module "school-gender" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_school_phase.tf
+++ b/aws/registers/register_school_phase.tf
@@ -14,5 +14,6 @@ module "school-phase" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_school_tag.tf
+++ b/aws/registers/register_school_tag.tf
@@ -14,5 +14,6 @@ module "school-tag" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_school_trust.tf
+++ b/aws/registers/register_school_trust.tf
@@ -14,5 +14,6 @@ module "school-trust" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_school_type.tf
+++ b/aws/registers/register_school_type.tf
@@ -14,5 +14,6 @@ module "school-type" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_social_housing_provider.tf
+++ b/aws/registers/register_social_housing_provider.tf
@@ -14,5 +14,6 @@ module "social-housing-provider" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_street.tf
+++ b/aws/registers/register_street.tf
@@ -14,5 +14,6 @@ module "street" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_street_custodian.tf
+++ b/aws/registers/register_street_custodian.tf
@@ -14,5 +14,6 @@ module "street-custodian" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_territory.tf
+++ b/aws/registers/register_territory.tf
@@ -14,5 +14,6 @@ module "territory" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/register_uk.tf
+++ b/aws/registers/register_uk.tf
@@ -14,5 +14,6 @@ module "uk" {
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"
 
+  enable_cdn = "${var.enable_cdn}"
   enable_availability_checks = "${var.enable_availability_checks}"
 }

--- a/aws/registers/variables.tf
+++ b/aws/registers/variables.tf
@@ -133,7 +133,11 @@ variable "codedeploy_service_role_arn" {
 
 // https
 variable "elb_certificate_arn" {}
-variable "cloudfront_certificate_arn" {}
+variable "cloudfront_certificate_arn" {
+  default = ""
+}
+
+variable "enable_cdn" {}
 
 // StatusCake
 variable "statuscake_username" {}


### PR DESCRIPTION
I've mirrored the configuration of what has been manually deployed, except for the TTLs which I've kept low until we know it's all good. I also specifically haven't changed DNS on *.register.gov.uk for the same reason.