### PR TITLE
Remove destructive, infrequently used tasks

### DIFF
--- a/aws/registers/Makefile
+++ b/aws/registers/Makefile
@@ -66,15 +66,6 @@ pull-config:
 push-config:
 	aws s3 cp environments/$(vpc).tfvars s3://registers-terraform-config
 
-remove-config:
-	aws s3 rm s3://registers-terraform-config/$(vpc).tfvars
-
-remove-bucket:
-	aws s3 rb s3://openregister.$(vpc).config --force
-
-remove-state:
-	aws s3 rm s3://registers-terraform-state/$(vpc).tfstate
-
 plan: configure-state
 	terraform plan $(defaults) -module-depth=$(module_depth)
 


### PR DESCRIPTION
These tasks seem a bit scary. I feel like the need to remove configs,
buckets and state happens so rarely it's not worth the risk of an
accidental tab-completion mistake from trashing important stuff.