### PR TITLE
Add `diff-config` task

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,9 +188,14 @@ Skip this if you have not created any new `.tf` or `.tfvars` files.
 ### Pushing local changes to terraform config
 
 The terraform config file for each environment is not stored in Git but is
-stored in S3. Any local changes made and applied should be pushed back to S3:
+stored in S3. Any local changes made and applied should be pushed back to S3.
+First check that the config hasn't changed since you last pulled:
 
 	cd aws/registers
+	make diff-config -e vpc=<name>
+
+And then push if the previous task reports that the files are identical:
+
 	make push-config -e vpc=<name>
 
 # Running the registers application

--- a/aws/registers/Makefile
+++ b/aws/registers/Makefile
@@ -10,6 +10,7 @@
 	purge-remote-state-cache \
 	pull-config \
 	push-config \
+	diff-config \
 	push-state
 
 export expected_terraform_version=v0.8.0
@@ -65,6 +66,9 @@ pull-config:
 
 push-config:
 	aws s3 cp environments/$(vpc).tfvars s3://registers-terraform-config
+
+diff-config:
+	bash -c "diff --report-identical-files environments/$(vpc).tfvars <(aws s3 cp s3://registers-terraform-config/$(vpc).tfvars -)"
 
 plan: configure-state
 	terraform plan $(defaults) -module-depth=$(module_depth)


### PR DESCRIPTION
It's currently clumsy having to manually check the variables you want to
push haven't been changed by someone else after you last pulled them.
Hopefully, this should make things slightly easier/safer.

I'm not overly happy with the `bash -c` bit but it means we can use
process substitution to avoid copying files locally.