### PR TITLE
Make Register register the default register

### DIFF
--- a/ansible/group_vars/tag_Environment_alpha
+++ b/ansible/group_vars/tag_Environment_alpha
@@ -77,6 +77,8 @@ register_groups:
     - territory
 
   multi:
+    - register
+
     - academy-school-eng
     - datatype
     - diocese

--- a/ansible/group_vars/tag_Environment_beta
+++ b/ansible/group_vars/tag_Environment_beta
@@ -33,10 +33,11 @@ register_groups:
     - territory
 
   multi:
+    - register
+
     - country
     - datatype
     - field
-    - register
     - local-authority-eng
     - local-authority-type
     - territory

--- a/ansible/group_vars/tag_Environment_discovery
+++ b/ansible/group_vars/tag_Environment_discovery
@@ -114,7 +114,8 @@ register_groups:
     - uk
 
   multi:
-    - address
+    - register
+
     - company
     - datatype
     - field
@@ -133,7 +134,6 @@ register_groups:
     - place
     - premises
     - prison
-    - register
     - street
     - street-custodian
     - uk

--- a/ansible/group_vars/tag_Environment_test
+++ b/ansible/group_vars/tag_Environment_test
@@ -22,4 +22,5 @@ register_groups:
 
   multi:
     - register
+
     - country


### PR DESCRIPTION
The ordering of which registers are on multi-tenanted register hosts is
important. It makes sense for the first, or "default" to a register we
expect to be in every environment.