### PR TITLE
Add custodian name to register config file template

### DIFF
--- a/ansible/group_vars/tag_Environment_alpha
+++ b/ansible/group_vars/tag_Environment_alpha
@@ -26,16 +26,24 @@ register_settings:
   address:
     enable_download_resource: false
   datatype:
+    custodian_name: Paul Downey
     enable_register_data_delete: false
   field:
+    custodian_name: Paul Downey
     enable_register_data_delete: false
   local-authority-eng:
+    custodian_name: Stephen McAllister
     history_page_url: https://registers-history.herokuapp.com/local-authority-eng
+  local-authority-type:
+    custodian_name: Stephen McAllister
   register:
+    custodian_name: Paul Downey
     enable_register_data_delete: false
   school-eng:
+    custodian_name: Andrew Thomson
     history_page_url: https://registers-history.herokuapp.com/school-eng
   territory:
+    custodian_name: Tony Worron
     history_page_url: https://registers-history.herokuapp.com/territory
 
 register_groups:

--- a/ansible/group_vars/tag_Environment_beta
+++ b/ansible/group_vars/tag_Environment_beta
@@ -9,12 +9,25 @@ registers:
   - territory
 
 register_settings:
-  local-authority-eng:
-    history_page_url: https://registers-history.herokuapp.com/local-authority-eng
   country:
+    custodian_name: Tony Worron
     history_page_url: https://registers-history.herokuapp.com/country
+  datatype:
+    custodian_name: Paul Downey
+  field:
+    custodian_name: Paul Downey
+  local-authority-eng:
+    custodian_name: Stephen McAllister
+    history_page_url: https://registers-history.herokuapp.com/local-authority-eng
+  local-authority-type:
+    custodian_name: Stephen McAllister
+  register:
+    custodian_name: Paul Downey
+  school-eng:
+    custodian_name: Andrew Thomson
   territory:
     history_page_url: https://registers-history.herokuapp.com/territory
+    custodian_name: Tony Worron
 
 register_groups:
   country:

--- a/ansible/roles/openregister_config/templates/openregister-config.yaml.j2
+++ b/ansible/roles/openregister_config/templates/openregister-config.yaml.j2
@@ -28,6 +28,8 @@ database:
 
 trackingId: {{ tracking_id }}
 register: {{ register_name }}
+{% if settings.custodian_name is defined %}custodianName: {{ settings.custodian_name }}{% endif %}
+
 enableDownloadResource: {{ settings.enable_download_resource | default(true) }}
 enableRegisterDataDelete: {{ settings.enable_register_data_delete | default(enable_register_data_delete) | default(false) }}
 {% if settings.history_page_url is defined %}historyPageUrl: {{ settings.history_page_url }}{% endif %}
@@ -63,6 +65,8 @@ registers:
         charSet: UTF-8
 
     trackingId: {{ tracking_id }}
+    {% if settings.custodian_name is defined %}custodianName: {{ settings.custodian_name }}{% endif %}
+
     enableDownloadResource: {{ settings.enable_download_resource | default(true) }}
     enableRegisterDataDelete: {{ settings.enable_register_data_delete | default(enable_register_data_delete) | default(false) }}
     {% if settings.history_page_url is defined %}historyPageUrl: {{ settings.history_page_url }}{% endif %}


### PR DESCRIPTION
This PR adds custodian name as an optional variable to the config file generated for each register, **in addition to** populating `custodianName` for certain Alpha and Beta registers.

As part of this change, note the extra newline added after each of the conditionals; this is required as the Jinja templating engine will strip out newline characters after conditionals, meaning that you end up with output something like `custodianName: John SmithenableDownloadResource: true` if this newline is omitted.

Jinja2  2.7 introduces a new flag `keep_trailing_newline` which resolves this issue - this can be viewed from the closed issue at https://github.com/ansible/ansible/issues/1220.