### PR TITLE
Add similar registers to register config files

### DIFF
--- a/ansible/group_vars/tag_Environment_alpha
+++ b/ansible/group_vars/tag_Environment_alpha
@@ -45,6 +45,8 @@ register_settings:
   territory:
     custodian_name: Tony Worron
     history_page_url: https://registers-history.herokuapp.com/territory
+    similar_registers:
+      - country
 
 register_groups:
   academy-school-eng:

--- a/ansible/group_vars/tag_Environment_beta
+++ b/ansible/group_vars/tag_Environment_beta
@@ -12,6 +12,8 @@ register_settings:
   country:
     custodian_name: Tony Worron
     history_page_url: https://registers-history.herokuapp.com/country
+    similar_registers:
+      - territory
   datatype:
     custodian_name: Paul Downey
   field:
@@ -28,6 +30,8 @@ register_settings:
   territory:
     history_page_url: https://registers-history.herokuapp.com/territory
     custodian_name: Tony Worron
+    similar_registers:
+      - country
 
 register_groups:
   country:

--- a/ansible/group_vars/tag_Environment_test
+++ b/ansible/group_vars/tag_Environment_test
@@ -11,6 +11,9 @@ register_settings:
     enable_register_data_delete: false
   address:
     enable_download_resource: false
+  country:
+    similar_registers:
+      - territory
 
 register_groups:
   register:

--- a/ansible/roles/openregister_config/templates/openregister-config.yaml.j2
+++ b/ansible/roles/openregister_config/templates/openregister-config.yaml.j2
@@ -34,6 +34,12 @@ enableDownloadResource: {{ settings.enable_download_resource | default(true) }}
 enableRegisterDataDelete: {{ settings.enable_register_data_delete | default(enable_register_data_delete) | default(false) }}
 {% if settings.history_page_url is defined %}historyPageUrl: {{ settings.history_page_url }}{% endif %}
 
+{% if settings.similar_registers is defined %}similarRegisters:
+  {% for register in settings.similar_registers -%}
+    - {{ register }}
+  {% endfor %}
+{% endif %}
+
 registerDomain: {{ register_domain }}
 externalConfigDirectory: /srv/openregister-java
 downloadConfigs: true
@@ -70,6 +76,12 @@ registers:
     enableDownloadResource: {{ settings.enable_download_resource | default(true) }}
     enableRegisterDataDelete: {{ settings.enable_register_data_delete | default(enable_register_data_delete) | default(false) }}
     {% if settings.history_page_url is defined %}historyPageUrl: {{ settings.history_page_url }}{% endif %}
+
+    {% if settings.similar_registers is defined %}similarRegisters:
+      {% for register in settings.similar_registers -%}
+        - {{ register }}
+      {% endfor %}
+    {% endif %}
 
     credentials:
       user: {{ app_user }}


### PR DESCRIPTION
This PR adds `similar_registers` to the Jinja template for generating register config files and updates the similar-registers for `country` and `territory` registers'.