### PR TITLE
Swap some registers to use the multi-tenanted instances

### DIFF
--- a/aws/modules/register/availiabilty_checks.tf
+++ b/aws/modules/register/availiabilty_checks.tf
@@ -15,3 +15,21 @@ resource "statuscake_test" "status_check_records" {
   contact_id = 55280
   count = "${signum(var.enable_availability_checks * var.instance_count)}"
 }
+
+resource "statuscake_test" "status_check_home_multi" {
+  count = "${var.enable_availability_checks * length(var.registers)}"
+  website_name = "${var.vpc_name} - ${element(var.registers, count.index)} - home"
+  website_url = "https://${element(aws_route53_record.multi.*.fqdn, count.index)}"
+  test_type = "HTTP"
+  check_rate = 60
+  contact_id = 55280
+}
+
+resource "statuscake_test" "status_check_records_multi" {
+  count = "${var.enable_availability_checks * length(var.registers)}"
+  website_name = "${var.vpc_name} - ${element(var.registers, count.index)} - home"
+  website_url = "https://${element(aws_route53_record.multi.*.fqdn, count.index)}/records"
+  test_type = "HTTP"
+  check_rate = 60
+  contact_id = 55280
+}

--- a/aws/modules/register/dns.tf
+++ b/aws/modules/register/dns.tf
@@ -6,3 +6,12 @@ resource "aws_route53_record" "load_balancer" {
   ttl = "${var.dns_ttl}"
   records = [ "${aws_elb.load_balancer.dns_name}" ]
 }
+
+resource "aws_route53_record" "multi" {
+  count = "${length(var.registers)}"
+  zone_id = "${var.dns_zone_id}"
+  name = "${element(var.registers, count.index)}.${var.vpc_name}.${var.dns_domain}"
+  type = "CNAME"
+  ttl = "${var.dns_ttl}"
+  records = [ "${aws_elb.load_balancer.dns_name}" ]
+}

--- a/aws/modules/register/variables.tf
+++ b/aws/modules/register/variables.tf
@@ -68,3 +68,7 @@ variable "enable_availability_checks" {
   default = false
   description = "Whether to enable availability health checks for this register"
 }
+
+variable "registers" {
+  default = []
+}

--- a/aws/registers/register_multi.tf
+++ b/aws/registers/register_multi.tf
@@ -15,4 +15,6 @@ module "multi" {
   certificate_arn = "${var.elb_certificate_arn}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+
+  registers = ["${var.multitenancy_groups["multi"]}"]
 }

--- a/aws/registers/variables.tf
+++ b/aws/registers/variables.tf
@@ -128,6 +128,10 @@ variable "instance_count" {
   }
 }
 
+variable "multitenancy_groups" {
+  type = "map"
+}
+
 // CodeDeploy
 variable "codedeploy_service_role_arn" {
   default = "arn:aws:iam::022990953738:role/code-deploy-role"


### PR DESCRIPTION
**tl;dr**: we want to get traffic on the new multi-tenanted registers. 
We still want to support the old, single register instances. There's some
ugliness here that can go away once we've proven multi-tenancy works.

At the moment this is implemented in a clumsy way. We're having to deal
with the situation where we have both single-register instances and
multi-tenanted instances. I suspect things are going to look a bit ugly
until we move everything to be on multi-tenanted instances (it would
still be okay for "multi-tenanted" instances to only provide one
register). At the moment the `register_*.tf` files represent two
distinct things: either an individual register or a group of registers.
I suspect once we move everything to being multi-tenanted they will all
represent the latter.

We are also having to define which registers run on multi-tenanted
instances in our Terraform configuration. This isn't ideal as we have to
configure this again for the Ansible tasks that generate application
config files. We should probably look at tying these things together.

Deploying these changes will currently do nothing. We also need to
change the Terraform `.tfvars` for each environment. We are doing this
separetly as we need to coordinate DNS changes so we don't end up with
multiple DNS entries for each register.  For example, without
coordinating DNS changes, we'll end up trying to deploy two CNAMEs for
`register.test.openregister.org`; one which points to the
single-register ELB and one that points to the multi-tenanted ELB. We
can tweak the DNS manually in this case and then set the instance count
for the register to `0` after we're happy things are working correctly.