### PR TITLE
Add address to the multi-tenanted register group in discovery

### DIFF
--- a/ansible/group_vars/tag_Environment_discovery
+++ b/ansible/group_vars/tag_Environment_discovery
@@ -115,6 +115,7 @@ register_groups:
 
   multi:
     - register
+    - address
     - company
     - datatype
     - field


### PR DESCRIPTION
Address is currently small in discovery so it seems sensible to run it next to the other registers.