### PR TITLE
Improve Make config diff-er task

### DIFF
--- a/aws/registers/Makefile
+++ b/aws/registers/Makefile
@@ -68,7 +68,7 @@ push-config:
 	aws s3 cp environments/$(vpc).tfvars s3://registers-terraform-config
 
 diff-config:
-	bash -c "diff --report-identical-files environments/$(vpc).tfvars <(aws s3 cp s3://registers-terraform-config/$(vpc).tfvars -)"
+	bash -c "diff --unified --report-identical-files environments/$(vpc).tfvars <(aws s3 cp s3://registers-terraform-config/$(vpc).tfvars -)"
 
 plan: configure-state
 	terraform plan $(defaults) -module-depth=$(module_depth)

--- a/aws/registers/Makefile
+++ b/aws/registers/Makefile
@@ -68,7 +68,7 @@ push-config:
 	aws s3 cp environments/$(vpc).tfvars s3://registers-terraform-config
 
 diff-config:
-	bash -c "diff --unified --report-identical-files environments/$(vpc).tfvars <(aws s3 cp s3://registers-terraform-config/$(vpc).tfvars -)"
+	bash -c "diff --unified --report-identical-files environments/$(vpc).tfvars <(aws s3 cp s3://registers-terraform-config/$(vpc).tfvars -); exit 0"
 
 plan: configure-state
 	terraform plan $(defaults) -module-depth=$(module_depth)


### PR DESCRIPTION
I've found the `diff-config` task really useful, however the output generated was using some weird diff format I'm unfamiliar with (ie it doesn't look like `git diff`), so I've mad it more `git diff`-y.

`diff` returns a non-zero exit code if there are differences to display. This bubbles up to `make` and shows an error when we have differences. I've made it so `make` always sees a zero exit code.