### PR TITLE
Use Route53 alias targets for ELBs

### DIFF
--- a/aws/modules/register/dns.tf
+++ b/aws/modules/register/dns.tf
@@ -2,7 +2,10 @@ resource "aws_route53_record" "multi" {
   count = "${length(var.registers)}"
   zone_id = "${var.dns_zone_id}"
   name = "${element(var.registers, count.index)}.${var.vpc_name}.${var.dns_domain}"
-  type = "CNAME"
-  ttl = "${var.dns_ttl}"
-  records = [ "${aws_elb.load_balancer.dns_name}" ]
+  type = "A"
+  alias {
+    name = "${aws_elb.load_balancer.dns_name}"
+    zone_id = "${aws_elb.load_balancer.zone_id}"
+    evaluate_target_health = false // we don't have anything to fail over to at the moment
+  }
 }


### PR DESCRIPTION
We can do some special Route53+ELB AWS magic which ties the ELBs and R53
records together so we don't have to even consider TTLs. In our case I
don't think it gets us very much but I can't really see a reason not to
use it.

> If an alias resource record set points to a CloudFront distribution, an
> Elastic Beanstalk environment, an ELB load balancer, or an Amazon S3
> bucket, you cannot set the time to live (TTL); Amazon Route 53 uses the
> CloudFront, Elastic Beanstalk, Elastic Load Balancing, or Amazon S3
> TTLs. If an alias resource record set points to another resource record
> set in the same hosted zone, Amazon Route 53 uses the TTL of the
> resource record set that the alias resource record set points to.
Source: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-choosing-alias-non-alias.html