### PR TITLE
Fix StatusCake names

### DIFF
--- a/aws/modules/register/availiabilty_checks.tf
+++ b/aws/modules/register/availiabilty_checks.tf
@@ -9,7 +9,7 @@ resource "statuscake_test" "status_check_home" {
 
 resource "statuscake_test" "status_check_records" {
   count = "${var.enable_availability_checks * length(var.registers)}"
-  website_name = "${var.vpc_name} - ${element(var.registers, count.index)} - home"
+  website_name = "${var.vpc_name} - ${element(var.registers, count.index)} - records"
   website_url = "https://${element(aws_route53_record.multi.*.fqdn, count.index)}/records"
   test_type = "HTTP"
   check_rate = 60


### PR DESCRIPTION
The checks were testing the correct endpoint but the name was incorrect.