### PR TITLE
[RFC] add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*]
+end_of_line = lf
+insert_final_newline = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,5 @@
+root = true
+
 [*]
 end_of_line = lf
 insert_final_newline = true


### PR DESCRIPTION
This adds an [editorconfig file][1] to force newline-at-end-of-file.

This is automatically recognised by IntelliJ IDEA and other JetBrains
products.  There are plugins for other editors:

 - vim: https://github.com/editorconfig/editorconfig-vim#readme
 - emacs: https://github.com/editorconfig/editorconfig-emacs#readme
 - sublime:
 - https://github.com/sindresorhus/editorconfig-sublime#readme

How do people feel about this? 👍 / 👎 ?

[1]: http://editorconfig.org/