### PR TITLE
Ensure refreshed configs have all records

### DIFF
--- a/ansible/refresh_register_field_config_in_s3.yml
+++ b/ansible/refresh_register_field_config_in_s3.yml
@@ -18,7 +18,7 @@
         - 'group_vars/tag_Environment_{{ vpc }}'
 
     - name: synchronize register register
-      shell: "curl -s https://register.{{ register_domain }}/records.yaml | aws s3 cp - s3://openregister.{{ vpc }}.config/registers.yaml"
+      shell: "curl -s 'https://register.{{ register_domain }}/records.yaml?page-size=5000' | aws s3 cp - s3://openregister.{{ vpc }}.config/registers.yaml"
 
     - name: synchronize field register
-      shell: "curl -s https://field.{{ register_domain }}/records.yaml | aws s3 cp - s3://openregister.{{ vpc }}.config/fields.yaml"
+      shell: "curl -s 'https://field.{{ register_domain }}/records.yaml?page-size=5000' | aws s3 cp - s3://openregister.{{ vpc }}.config/fields.yaml"


### PR DESCRIPTION
When the registers size is over 100 we start paginate hence the solution is to specify the max allowed size for 1 request which is 5000