### PR TITLE
Add logging section to config template

### DIFF
--- a/ansible/roles/openregister_config/templates/openregister-config.yaml.j2
+++ b/ansible/roles/openregister_config/templates/openregister-config.yaml.j2
@@ -51,6 +51,14 @@ credentials:
   user: {{ app_user }}
   password: {{ app_password }}
 
+# Logging settings.
+logging:
+  level: WARN
+  appenders:
+    - type: console
+      target: stdout
+      logFormat: "%-5p [%d{ISO8601}] %X{register} %c: %m %replace(%rEx){'\n','\\n'}%nopex%n"
+
 {% if loop.length > 1 %}
 registers:
 {% endif %}


### PR DESCRIPTION
Logging section was previously missing from all register configs. This PR adds logging to the config template so that we log the register name which was responsible for creating the particular log entry.

Paired with @johnollier 