### PR TITLE
Remove data duplication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ tls-certs/*
 !aws/tls-certs/terraform.tfstate
 !aws/tls-certs/terraform.tfstate.backup
 !aws/tls-certs/terraform.tfvars
+.venv

--- a/README.md
+++ b/README.md
@@ -80,12 +80,17 @@ environment.  However you will probably want to override at least the
 
 `vi ansible/group_vars/tag_Environment_<vpc>`
 
-	registers:
-	  - country
-	  - other-register
-	  - another-register
-    
     register_domain: my-environment.openregister.org
+    
+    register_groups:
+      basic:
+        - register
+        - field
+        - datatype
+      multi:
+        - country
+        - other-register
+        - another-register
 
 ### Generate credentials
 

--- a/ansible/generate_passwords.yml
+++ b/ansible/generate_passwords.yml
@@ -9,8 +9,6 @@
 
   vars:
     password_length: 10
-    app_services:
-      - mint
 
   tasks:
     - stat: path="group_vars/tag_Environment_{{ vpc }}"
@@ -20,16 +18,15 @@
       when: overrides.stat.exists
 
     - name: Generate application passwords
-      command: "pass generate --no-symbols {{ vpc }}/app/{{ item.1 }}/{{ item.0 }} {{ password_length }}"
+      command: "pass generate --no-symbols {{ vpc }}/app/mint/{{ item }} {{ password_length }}"
       args:
-        creates: "{{ pass_store_location | expanduser }}/{{ vpc }}/app/{{ item.1 }}/{{ item.0 }}.gpg"
-      with_nested:
-        - "{{ registers }}"
-        - "{{ app_services }}"
+        creates: "{{ pass_store_location | expanduser }}/{{ vpc }}/app/mint/{{ item }}.gpg"
+      with_flattened:
+        - "{{ register_groups.values() }}"
 
     - name: Generate RDS passwords
       command: "pass generate --no-symbols {{ vpc }}/rds/openregister/{{ item }} {{ password_length }}"
       args:
         creates: "{{ pass_store_location | expanduser }}/{{ vpc }}/rds/openregister/{{ item }}.gpg"
-      with_items:
-        - "{{ registers | union(['master']) }}"
+      with_flattened:
+        - "{{ register_groups.values() | union(['master']) }}"

--- a/ansible/group_vars/tag_Environment_alpha
+++ b/ansible/group_vars/tag_Environment_alpha
@@ -1,23 +1,3 @@
-registers:
-  - academy-school-eng
-  - datatype
-  - diocese
-  - field
-  - la-maintained-school-eng
-  - local-authority-eng
-  - local-authority-type
-  - register
-  - religious-character
-  - school-admissions-policy
-  - school-authority-eng
-  - school-eng
-  - school-gender
-  - school-phase
-  - school-tag
-  - school-trust
-  - school-type
-  - territory
-
 register_domain: alpha.openregister.org
 
 enable_register_data_delete: true

--- a/ansible/group_vars/tag_Environment_beta
+++ b/ansible/group_vars/tag_Environment_beta
@@ -1,13 +1,4 @@
 register_domain: register.gov.uk
-registers:
-  - country
-  - datatype
-  - field
-  - register
-  - local-authority-eng
-  - local-authority-type
-  - territory
-
 register_settings:
   country:
     custodian_name: Tony Worron

--- a/ansible/group_vars/tag_Environment_discovery
+++ b/ansible/group_vars/tag_Environment_discovery
@@ -1,38 +1,3 @@
-registers:
-  - address
-  - company
-  - court
-  - datatype
-  - dental-practice
-  - field
-  - food-authority
-  - food-premises
-  - food-premises-rating
-  - food-premises-type
-  - government-domain
-  - government-organisation
-  - government-website
-  - gp-practice
-  - industry
-  - internal-drainage-board
-  - job-centre
-  - jobcentre
-  - local-authority-eng
-  - local-authority-nir
-  - local-authority-sct
-  - local-authority-type
-  - local-authority-wls
-  - place
-  - police-force
-  - premises
-  - prison
-  - register
-  - register-office
-  - social-housing-provider
-  - street
-  - street-custodian
-  - uk
-
 register_domain: discovery.openregister.org
 
 enable_register_data_delete: true

--- a/ansible/group_vars/tag_Environment_test
+++ b/ansible/group_vars/tag_Environment_test
@@ -1,9 +1,4 @@
 register_domain: test.openregister.org
-registers:
-  - address
-  - country
-  - field
-  - register
 
 enable_register_data_delete: true
 

--- a/ansible/letsencrypt.yml
+++ b/ansible/letsencrypt.yml
@@ -38,7 +38,7 @@
     - name: compute domains list
       set_fact:
         fqdn: '{{ item }}.{{ register_domain }}'
-      with_items: '{{ registers | union([ "www" ]) }}'
+      with_flattened: '{{ register_groups.values() | union([ "www" ]) }}'
       register: output
 
     - set_fact: domains="{{ output.results | map(attribute='ansible_facts.fqdn') | list }}"

--- a/ansible/roles/database/tasks/databases.yml
+++ b/ansible/roles/database/tasks/databases.yml
@@ -6,6 +6,6 @@
     login_host="{{ groups[inventory_group_name][0] }}"
     login_password="{{ master_password }}"
     login_user="{{ master_user }}"
-  with_items: "{{ registers }}"
+  with_flattened: "{{ register_groups.values() }}"
   register: create_db
   run_once: true

--- a/ansible/roles/database/tasks/user.yml
+++ b/ansible/roles/database/tasks/user.yml
@@ -10,7 +10,7 @@
     login_host="{{ groups[inventory_group_name][0] }}"
     login_user="{{ master_user }}"
     login_password="{{ master_password }}"
-  with_items: "{{ registers }}"
+  with_flattened: "{{ register_groups.values() }}"
   when: create_db
 
 - name: Set privileges for user
@@ -23,4 +23,4 @@
     login_host="{{ groups[inventory_group_name][0] }}"
     login_user="{{ item }}_openregister"
     login_password="{{ lookup('pass', '{{ vpc }}/rds/openregister/{{ item }}') }}"
-  with_items: "{{ registers }}"
+  with_flattened: "{{ register_groups.values() }}"


### PR DESCRIPTION
The `registers` variable contains duplicate data to the
`register_groups` variable.  This means that when we add a new
register we need to remember to add it to both lists.

This commit changes the ansible scripts to use
`register_groups.values()`, flattened, in order to have a single
source of truth for which registers exist in an environment.

(This will also make the README simpler when I update it)