### PR TITLE
Set trim_blocks to false

### DIFF
--- a/ansible/roles/openregister_config/templates/openregister-config.yaml.j2
+++ b/ansible/roles/openregister_config/templates/openregister-config.yaml.j2
@@ -1,3 +1,5 @@
+#jinja2: trim_blocks: False
+
 {% for reg in item.value -%}
   {%- set rds_instance_name = vpc + "-openregister-db" -%}
   {%- set password_store_key = vpc + "/rds/openregister/" + reg -%}
@@ -31,16 +33,13 @@ database:
 trackingId: {{ tracking_id }}
 register: {{ register_name }}
 {% if settings.custodian_name is defined %}custodianName: {{ settings.custodian_name }}{% endif %}
-
 enableDownloadResource: {{ settings.enable_download_resource | default(true) }}
 enableRegisterDataDelete: {{ settings.enable_register_data_delete | default(enable_register_data_delete) | default(false) }}
 
 fieldsYamlLocation: {{ settings.fields_yaml_location | default(default_field_register_url) }}
-
 registersYamlLocation: {{ settings.registers_yaml_location | default(default_register_register_url) }}
 
 {% if settings.history_page_url is defined %}historyPageUrl: {{ settings.history_page_url }}{% endif %}
-
 {% if settings.similar_registers is defined %}similarRegisters:
   {% for register in settings.similar_registers -%}
     - {{ register }}
@@ -87,11 +86,9 @@ registers:
 
     trackingId: {{ tracking_id }}
     {% if settings.custodian_name is defined %}custodianName: {{ settings.custodian_name }}{% endif %}
-
     enableDownloadResource: {{ settings.enable_download_resource | default(true) }}
     enableRegisterDataDelete: {{ settings.enable_register_data_delete | default(enable_register_data_delete) | default(false) }}
     {% if settings.history_page_url is defined %}historyPageUrl: {{ settings.history_page_url }}{% endif %}
-
     {% if settings.similar_registers is defined %}similarRegisters:
       {% for register in settings.similar_registers -%}
         - {{ register }}


### PR DESCRIPTION
This PR is to remove the hack we previously had to make where we inserted a new line after conditional template blocks. Failure to insert a new line after a conditional block would lead to the situation along the lines of `custodianName: JohnSmithenableDownloadResource: true`.

In the config template file I am specifying `trim_blocks: False` to force Jinja2 to keep the first new line after a template block; by default it will remove the first new line (see http://docs.ansible.com/ansible/template_module.html towards the bottom).