### PR TITLE
Do not pull java docker images on instance creation.

### DIFF
--- a/aws/registers/templates/users.yaml
+++ b/aws/registers/templates/users.yaml
@@ -141,6 +141,4 @@ runcmd:
   - [ chkconfig, yum-cron, on ]
   - [ service, docker, start ]
   - [ chkconfig, docker, on ]
-  - [ docker, pull, jstepien/openjdk8 ] # make this available for app deployments
-  - [ docker, pull, openjdk:8-jre-alpine ] # make this available for app deployments
   - [ /usr/local/bin/setup-cdagent.sh ]


### PR DESCRIPTION
Currently when an instance is created the docker image for java is pulled from docker hub. However it works fine if the image is downloaded the first time the application is deployed onto a new instance, so the pull step is unnecessary. 