### PR TITLE
Allow Terraform patch-level version updates

### DIFF
--- a/aws/cloudtrail/Makefile
+++ b/aws/cloudtrail/Makefile
@@ -5,11 +5,11 @@
 	plan \
 	plan-destroy
 
-export expected_terraform_version=v0.7.13
-export actual_terraform_version=$(shell terraform version | head -n 1 | cut -f2 -d" ")
+export expected_terraform_version=v0.7
+export actual_terraform_version=$(shell terraform version | head -n 1 | cut -f2 -d" " | cut -d"." -f1,2)
 
 ifneq ($(expected_terraform_version), $(actual_terraform_version))
-	$(error Expected terraform version $(expected_terraform_version), but saw $(actual_terraform_version))
+  $(error Expected terraform version $(expected_terraform_version).x, but saw $(actual_terraform_version).x)
 endif
 
 # Default terraform plan -module-depth= value

--- a/aws/registers/Makefile
+++ b/aws/registers/Makefile
@@ -13,11 +13,11 @@
 	diff-config \
 	push-state
 
-export expected_terraform_version=v0.8.0
-export actual_terraform_version=$(shell terraform version | head -n 1 | cut -f2 -d" ")
+export expected_terraform_version=v0.8
+export actual_terraform_version=$(shell terraform version | head -n 1 | cut -f2 -d" " | cut -d"." -f1,2)
 
 ifneq ($(expected_terraform_version), $(actual_terraform_version))
-  $(error Expected terraform version $(expected_terraform_version), but saw $(actual_terraform_version))
+  $(error Expected terraform version $(expected_terraform_version).x, but saw $(actual_terraform_version).x)
 endif
 
 ifndef vpc

--- a/aws/sumologic/Makefile
+++ b/aws/sumologic/Makefile
@@ -7,14 +7,14 @@
 	plan-destroy \
 	push-state
 
-export expected_terraform_version=v0.7.13
-export actual_terraform_version=$(shell terraform version | head -n 1 | cut -f2 -d" ")
+export expected_terraform_version=v0.7
+export actual_terraform_version=$(shell terraform version | head -n 1 | cut -f2 -d" " | cut -d"." -f1,2)
 
 export expected_node_version=v7.1.0
 export actual_node_version=$(shell node --version | head -n 1)
 
 ifneq ($(expected_terraform_version), $(actual_terraform_version))
-	$(error Expected terraform version $(expected_terraform_version), but saw $(actual_terraform_version))
+  $(error Expected terraform version $(expected_terraform_version).x, but saw $(actual_terraform_version).x)
 endif
 
 ifneq ($(expected_node_version), $(actual_node_version))


### PR DESCRIPTION
It's annoying to have to bump the expected version of Terraform we use
for every individual Terraform release.

We're going to allow patch-level Terraform auto-updates with the
assumption that upgrades inside the same minor release are unlikely to
break things in a way that can't easily be fixed.

We still need to update the old `v0.7.x` usages of Terraform but those 
changes will be more involved and can happen separately.