### PR TITLE
Clean-up temporary DNS hosted zone

### DIFF
--- a/aws/modules/register/dns.tf
+++ b/aws/modules/register/dns.tf
@@ -1,9 +1,9 @@
 resource "aws_route53_record" "record" {
-  count = "${var.enabled ? 2 : 0}"
+  count = "${var.enabled ? 1 : 0}"
 
   name = "${var.name}"
   type = "A"
-  zone_id = "${element(var.dns_zone_id, count.index)}"
+  zone_id = "${var.dns_zone_id}"
 
   alias {
     name = "${var.load_balancer["dns_name"]}"

--- a/aws/modules/register/variables.tf
+++ b/aws/modules/register/variables.tf
@@ -11,7 +11,6 @@ variable enabled {
 }
 
 variable dns_zone_id {
-  type = "list"
   description = "the Route 53 DNS zone to create these records in"
 }
 

--- a/aws/registers/registers.tf
+++ b/aws/registers/registers.tf
@@ -1,8 +1,3 @@
-resource "aws_route53_zone" "temporary_hosted_zone" {
-  name = "${var.vpc_name}.openregister.org"
-  comment = "Temporary whilst migrating to separate Terraform resources for each DNS record"
-}
-
 module "address_register" {
   source = "../modules/register"
   enabled = "${lookup(var.enabled_registers, "address", false)}"
@@ -10,7 +5,7 @@ module "address_register" {
   name = "address"
   environment = "${var.vpc_name}"
   load_balancer = "${module.address.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -22,7 +17,7 @@ module "academy-school-eng_register" {
   name = "academy-school-eng"
   environment = "${var.vpc_name}"
   load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -34,7 +29,7 @@ module "company_register" {
   name = "company"
   environment = "${var.vpc_name}"
   load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -46,7 +41,7 @@ module "country_register" {
   name = "country"
   environment = "${var.vpc_name}"
   load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -58,7 +53,7 @@ module "datatype_register" {
   name = "datatype"
   environment = "${var.vpc_name}"
   load_balancer = "${module.basic.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -70,7 +65,7 @@ module "diocese_register" {
   name = "diocese"
   environment = "${var.vpc_name}"
   load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -82,7 +77,7 @@ module "field_register" {
   name = "field"
   environment = "${var.vpc_name}"
   load_balancer = "${module.basic.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -94,7 +89,7 @@ module "food-authority_register" {
   name = "food-authority"
   environment = "${var.vpc_name}"
   load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -106,7 +101,7 @@ module "food-premises_register" {
   name = "food-premises"
   environment = "${var.vpc_name}"
   load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -118,7 +113,7 @@ module "food-premises-rating_register" {
   name = "food-premises-rating"
   environment = "${var.vpc_name}"
   load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -130,7 +125,7 @@ module "food-premises-type_register" {
   name = "food-premises-type"
   environment = "${var.vpc_name}"
   load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -142,7 +137,7 @@ module "government-domain_register" {
   name = "government-domain"
   environment = "${var.vpc_name}"
   load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -154,7 +149,7 @@ module "industry_register" {
   name = "industry"
   environment = "${var.vpc_name}"
   load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -166,7 +161,7 @@ module "jobcentre_register" {
   name = "jobcentre"
   environment = "${var.vpc_name}"
   load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -178,7 +173,7 @@ module "la-maintained-school-eng_register" {
   name = "la-maintained-school-eng"
   environment = "${var.vpc_name}"
   load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -190,7 +185,7 @@ module "local-authority-eng_register" {
   name = "local-authority-eng"
   environment = "${var.vpc_name}"
   load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -202,7 +197,7 @@ module "local-authority-nir_register" {
   name = "local-authority-nir"
   environment = "${var.vpc_name}"
   load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -214,7 +209,7 @@ module "local-authority-sct_register" {
   name = "local-authority-sct"
   environment = "${var.vpc_name}"
   load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -226,7 +221,7 @@ module "local-authority-type_register" {
   name = "local-authority-type"
   environment = "${var.vpc_name}"
   load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -238,7 +233,7 @@ module "local-authority-wls_register" {
   name = "local-authority-wls"
   environment = "${var.vpc_name}"
   load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -250,7 +245,7 @@ module "place_register" {
   name = "place"
   environment = "${var.vpc_name}"
   load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -262,7 +257,7 @@ module "premises_register" {
   name = "premises"
   environment = "${var.vpc_name}"
   load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -274,7 +269,7 @@ module "prison_register" {
   name = "prison"
   environment = "${var.vpc_name}"
   load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -286,7 +281,7 @@ module "register_register" {
   name = "register"
   environment = "${var.vpc_name}"
   load_balancer = "${module.basic.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -298,7 +293,7 @@ module "religious-character_register" {
   name = "religious-character"
   environment = "${var.vpc_name}"
   load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -310,7 +305,7 @@ module "school-admissions-policy_register" {
   name = "school-admissions-policy"
   environment = "${var.vpc_name}"
   load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -322,7 +317,7 @@ module "school-authority-eng_register" {
   name = "school-authority-eng"
   environment = "${var.vpc_name}"
   load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -334,7 +329,7 @@ module "school-eng_register" {
   name = "school-eng"
   environment = "${var.vpc_name}"
   load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -346,7 +341,7 @@ module "school-gender_register" {
   name = "school-gender"
   environment = "${var.vpc_name}"
   load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -358,7 +353,7 @@ module "school-phase_register" {
   name = "school-phase"
   environment = "${var.vpc_name}"
   load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -370,7 +365,7 @@ module "school-tag_register" {
   name = "school-tag"
   environment = "${var.vpc_name}"
   load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -382,7 +377,7 @@ module "school-trust_register" {
   name = "school-trust"
   environment = "${var.vpc_name}"
   load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -394,7 +389,7 @@ module "school-type_register" {
   name = "school-type"
   environment = "${var.vpc_name}"
   load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -406,7 +401,7 @@ module "street_register" {
   name = "street"
   environment = "${var.vpc_name}"
   load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -418,7 +413,7 @@ module "street-custodian_register" {
   name = "street-custodian"
   environment = "${var.vpc_name}"
   load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -430,7 +425,7 @@ module "territory_register" {
   name = "territory"
   environment = "${var.vpc_name}"
   load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }
@@ -442,7 +437,7 @@ module "uk_register" {
   name = "uk"
   environment = "${var.vpc_name}"
   load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = ["${aws_route53_zone.temporary_hosted_zone.zone_id}", "${module.core.dns_zone_id}"]
+  dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
 }


### PR DESCRIPTION
The `terraform plan` won't be particularly clear. We'll need to do some stuff with target and state removal in order to get this to apply without any downtime. Something like this:

1. `terraform apply -target=module.core.aws_route53_record.zone_delegation` (swap back to the hosted zone that `core` creates).
2. `terraform apply -target=module.{register, dataype, country, ...}_register.aws_route53_record.record` (delete the old record in the temporary hosted zone and create it in the new hosted zone, where it already exists with the same configuration and will silently reapply without changes).
3. `terraform state rm module.{register, dataype, country, ...}_register.aws_route53_record.record.1` (stop tracking any dangling resources, this might end up not being required).