### PR TITLE
Set the TTL for NS delegation of subdomains on openregister.org

### DIFF
--- a/aws/modules/core/route53.tf
+++ b/aws/modules/core/route53.tf
@@ -11,7 +11,7 @@ resource "aws_route53_record" "bastion" {
 }
 
 resource "aws_route53_record" "zone_delegation" {
-  zone_id = "${var.dns_parent_zone_id}"
+  zone_id = "${aws_route53_zone.core.zone_id}"
   name = "${var.vpc_name}.${var.dns_domain}"
   type = "NS"
   ttl = "${var.dns_ttl}"


### PR DESCRIPTION
I think the right thing was trying to be achieved here (ie trying to
keep the NS delegation for `{test, discovery, ...}.openregister.org`
short so it can be changed easily). However, the TTL here is for the
NS record in the wrong zone.

NS records at the point-of-delegation are non-authoritative. It is the
TTL of the NS record in the authoritative zone that is respected:

>  Defined in RFC 1035. NS RRs appear in two places. Within the zone file,
>  in which case they are authoritative records for the zone's name
>  servers. At the point of delegation for either a subdomain of the zone
>  or in the zone's parent in which case they are non-authoritative. Thus,
>  the zone example.com's parent zone (.com) will contain
>  non-authoritative NS RRs for the zone example.com at its point of
>  delegation (point of delegation is the term frequently used to describe
>  the NS RRs in the parent that delegate a zone of subdomain) and
>  subdomain.example.com will have non-authoritative NS RRS in the zone
>  example.com at its point of delegation. NS RRs at a point of delegation
>  are never authoritative only NS RRs within the zone are regarded as
>  authoritative. While this may look a fairly trivial point, is has
>  important implications for DNSSEC.

Source: http://www.zytrax.com/books/dns/ch8/ns.html

Deploying
----------

The current plan for this in the test environment is:

```
-/+ module.core.aws_route53_record.zone_delegation
    fqdn:               "test.openregister.org" => "<computed>"
    name:               "test.openregister.org" => "test.openregister.org"
    records.#:          "4" => "4"
    records.1217762515: "ns-607.awsdns-11.net" => "ns-607.awsdns-11.net"
    records.1440870510: "ns-2041.awsdns-63.co.uk" => "ns-2041.awsdns-63.co.uk"
    records.3777510865: "ns-1310.awsdns-35.org" => "ns-1310.awsdns-35.org"
    records.4230963353: "ns-201.awsdns-25.com" => "ns-201.awsdns-25.com"
    ttl:                "300" => "300"
    type:               "NS" => "NS"
    zone_id:            "<parent-zone>" => "<delegated-zone>" (forces new resource)
```

I think we'll need to be careful about applying this change because it appears as though it will try to delete NS records in the parent zone in R53 which should(?) cause an error. It might be sensible to first remove the resource from Terraform's state file (with `terraform state rm`) before applying.

The TTL on the NS records at the point-of-delegation should probably be reset to their defaults too.