### PR TITLE
Prefer source/destination security groups over CIDRs

### DIFF
--- a/aws/modules/core/bastion_security_group.tf
+++ b/aws/modules/core/bastion_security_group.tf
@@ -19,15 +19,6 @@ resource "aws_security_group_rule" "inbound_ssh" {
 }
 
 // Egress rules
-resource "aws_security_group_rule" "outbound_ssh" {
-  security_group_id = "${aws_security_group.bastionsg.id}"
-  type = "egress"
-  from_port = "22"
-  to_port = "22"
-  protocol = "tcp"
-  cidr_blocks = ["${var.vpc_cidr_block}"]
-}
-
 resource "aws_security_group_rule" "outbound_dns" {
   security_group_id = "${aws_security_group.bastionsg.id}"
   type = "egress"

--- a/aws/modules/core/outputs.tf
+++ b/aws/modules/core/outputs.tf
@@ -27,6 +27,7 @@ output "s3_bucket_id" {
 output "s3_bucket_name" {
   value = "${aws_s3_bucket.register.name}"
 }
+
 /*
  * subnets.tf exports
 */

--- a/aws/modules/database/outputs.tf
+++ b/aws/modules/database/outputs.tf
@@ -1,11 +1,3 @@
-output "id" {
-  value = "${aws_db_instance.db.id}"
-}
-
-output "instance" {
-  value = "${aws_db_instance.db.address}"
-}
-
 output "security_group_id" {
   value = "${aws_security_group.db.id}"
 }

--- a/aws/modules/database/security_group.tf
+++ b/aws/modules/database/security_group.tf
@@ -8,12 +8,3 @@ resource "aws_security_group" "db" {
     Environment = "${var.vpc_name}"
   }
 }
-
-resource "aws_security_group_rule" "inbound_postgres" {
-  security_group_id = "${aws_security_group.db.id}"
-  type = "ingress"
-  from_port = 5432
-  to_port = 5432
-  protocol = "tcp"
-  cidr_blocks = "${var.allow_from}"
-}

--- a/aws/modules/database/variables.tf
+++ b/aws/modules/database/variables.tf
@@ -14,8 +14,6 @@ variable "count" {
 variable "password" {}
 variable "username" {}
 
-variable "allow_from" { type = "list" }
-
 variable "multi_az" {
   default = "false"
 }

--- a/aws/modules/openregister/outputs.tf
+++ b/aws/modules/openregister/outputs.tf
@@ -5,7 +5,3 @@ output "cidr_block" {
 output "subnet_ids" {
   value = ["${aws_subnet.openregister.*.id}"]
 }
-
-output "security_group_id" {
-  value = "${aws_security_group.openregister.id}"
-}

--- a/aws/modules/openregister/variables.tf
+++ b/aws/modules/openregister/variables.tf
@@ -14,5 +14,3 @@ variable "zones" {
     "2" = "eu-west-1c"
   }
 }
-
-variable "bastion_security_group_id" {}

--- a/aws/modules/register_group/elb.tf
+++ b/aws/modules/register_group/elb.tf
@@ -62,6 +62,6 @@ resource "aws_security_group" "load_balancer" {
     from_port = 80
     to_port = 80
     protocol = "TCP"
-    security_groups = ["${var.security_group_ids}"]
+    security_groups = ["${aws_security_group.openregister.id}"]
   }
 }

--- a/aws/modules/register_group/instance.tf
+++ b/aws/modules/register_group/instance.tf
@@ -4,7 +4,7 @@ resource "aws_instance" "instance" {
   instance_type = "${var.instance_type}"
   subnet_id = "${element(var.subnet_ids, count.index)}"
   user_data = "${var.user_data}"
-  vpc_security_group_ids = [ "${var.security_group_ids}" ]
+  vpc_security_group_ids = [ "${aws_security_group.openregister.id}" ]
   iam_instance_profile = "${aws_iam_instance_profile.instance_profile.name}"
 
   root_block_device = {

--- a/aws/modules/register_group/instance_security_group.tf
+++ b/aws/modules/register_group/instance_security_group.tf
@@ -1,3 +1,21 @@
+resource "aws_security_group_rule" "bastion_outbound_ssh" {
+  security_group_id = "${var.bastion_security_group_id}"
+  type = "egress"
+  from_port = "22"
+  to_port = "22"
+  protocol = "tcp"
+  source_security_group_id = "${aws_security_group.openregister.id}"
+}
+
+resource "aws_security_group_rule" "inbound_postgres" {
+  security_group_id = "${var.database_security_group_id}"
+  type = "ingress"
+  from_port = 5432
+  to_port = 5432
+  protocol = "tcp"
+  source_security_group_id = "${aws_security_group.openregister.id}"
+}
+
 resource "aws_security_group" "openregister" {
   name = "${var.vpc_name}-${var.id}-openregister-sg"
   description = "Openregister EC2 Instance security group"

--- a/aws/modules/register_group/instance_security_group.tf
+++ b/aws/modules/register_group/instance_security_group.tf
@@ -1,5 +1,5 @@
 resource "aws_security_group" "openregister" {
-  name = "${var.id}-sg"
+  name = "${var.vpc_name}-${var.id}-openregister-sg"
   description = "Openregister EC2 Instance security group"
   vpc_id = "${var.vpc_id}"
 
@@ -9,7 +9,6 @@ resource "aws_security_group" "openregister" {
   }
 }
 
-// Ingress Rules
 resource "aws_security_group_rule" "inbound_ssh" {
   security_group_id = "${aws_security_group.openregister.id}"
   type = "ingress"
@@ -25,10 +24,9 @@ resource "aws_security_group_rule" "inbound_http" {
   from_port = 80
   to_port = 80
   protocol = "tcp"
-  cidr_blocks = [ "0.0.0.0/0" ]
+  source_security_group_id = "${aws_security_group.load_balancer.id}"
 }
 
-// Egress Rules
 resource "aws_security_group_rule" "outbound_dns" {
   security_group_id = "${aws_security_group.openregister.id}"
   type = "egress"
@@ -62,5 +60,5 @@ resource "aws_security_group_rule" "outbound_postgres" {
   from_port = 5432
   to_port = 5432
   protocol = "tcp"
-  cidr_blocks = "${var.db_cidr_blocks}"
+  source_security_group_id = "${var.database_security_group_id}"
 }

--- a/aws/modules/register_group/variables.tf
+++ b/aws/modules/register_group/variables.tf
@@ -37,11 +37,6 @@ variable "public_subnet_ids" {
   type = "list"
 }
 
-variable "security_group_ids" {
-  description = "list of security groups to attach EC2 instances to"
-  type = "list"
-}
-
 variable "private_dns_zone_id" {
   description = "Route 53 hosted zone id for DNS records for EC2 instances (ie private records)"
 }
@@ -62,4 +57,12 @@ variable "dns_domain" {
 
 variable "certificate_arn" {
   description = "ARN for TLS certificate for ELB"
+}
+
+variable "database_security_group_id" {
+  description = "security group of the database to allow register application egress access to"
+}
+
+variable "bastion_security_group_id" {
+  description = "security group of the bastion box to allow ingress access to register application instances from"
 }

--- a/aws/registers/openregister.tf
+++ b/aws/registers/openregister.tf
@@ -20,8 +20,6 @@ module "openregister_db" {
 
   cidr_blocks = "${var.openregister_database_cidr_blocks}"
 
-  allow_from = "${var.openregister_cidr_blocks}"
-
   instance_class = "${var.openregister_database_class_instance}"
   parameter_group_name = "${lookup(var.rds_parameter_group_name, "openregister")}"
 

--- a/aws/registers/openregister.tf
+++ b/aws/registers/openregister.tf
@@ -8,7 +8,6 @@ module "openregister" {
   cidr_blocks = "${var.openregister_cidr_blocks}"
   db_cidr_blocks = "${var.openregister_database_cidr_blocks}"
 
-  bastion_security_group_id = "${module.core.bastion_security_group_id}"
   public_route_table_id = "${module.core.public_route_table_id}"
 }
 

--- a/aws/registers/register_group_address.tf
+++ b/aws/registers/register_group_address.tf
@@ -9,8 +9,10 @@ module "address" {
   private_dns_zone_id = "${module.core.private_dns_zone_id}"
   subnet_ids = "${module.openregister.subnet_ids}"
   public_subnet_ids = "${module.core.public_subnet_ids}"
-  security_group_ids = ["${module.openregister.security_group_id}"]
   user_data = "${data.template_file.user_data.rendered}"
+
+  database_security_group_id = "${module.openregister_db.security_group_id}"
+  bastion_security_group_id = "${module.core.bastion_security_group_id}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"

--- a/aws/registers/register_group_basic.tf
+++ b/aws/registers/register_group_basic.tf
@@ -9,8 +9,10 @@ module "basic" {
   private_dns_zone_id = "${module.core.private_dns_zone_id}"
   subnet_ids = "${module.openregister.subnet_ids}"
   public_subnet_ids = "${module.core.public_subnet_ids}"
-  security_group_ids = ["${module.openregister.security_group_id}"]
   user_data = "${data.template_file.user_data.rendered}"
+
+  database_security_group_id = "${module.openregister_db.security_group_id}"
+  bastion_security_group_id = "${module.core.bastion_security_group_id}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"

--- a/aws/registers/register_group_multi.tf
+++ b/aws/registers/register_group_multi.tf
@@ -9,8 +9,10 @@ module "multi" {
   private_dns_zone_id = "${module.core.private_dns_zone_id}"
   subnet_ids = "${module.openregister.subnet_ids}"
   public_subnet_ids = "${module.core.public_subnet_ids}"
-  security_group_ids = ["${module.openregister.security_group_id}"]
   user_data = "${data.template_file.user_data.rendered}"
+
+  database_security_group_id = "${module.openregister_db.security_group_id}"
+  bastion_security_group_id = "${module.core.bastion_security_group_id}"
 
   dns_zone_id = "${module.core.dns_zone_id}"
   certificate_arn = "${var.elb_certificate_arn}"


### PR DESCRIPTION
This is a refactoring to make all security group rules reference other security groups to restrict source/destination traffic. We are no longer using CIDRs (other than `0.0.0.0/0` and office IPs) to control traffic.

This hopefully captures the intention behind rules as well as making things slightly more secure(?).