### PR TITLE
Create SGs for register groups only in environments that have them

### DIFF
--- a/aws/modules/register_group/instance_security_group.tf
+++ b/aws/modules/register_group/instance_security_group.tf
@@ -1,4 +1,6 @@
 resource "aws_security_group_rule" "bastion_outbound_ssh" {
+  count = "${signum(var.instance_count)}"
+
   security_group_id = "${var.bastion_security_group_id}"
   type = "egress"
   from_port = "22"
@@ -8,6 +10,8 @@ resource "aws_security_group_rule" "bastion_outbound_ssh" {
 }
 
 resource "aws_security_group_rule" "inbound_postgres" {
+  count = "${signum(var.instance_count)}"
+
   security_group_id = "${var.database_security_group_id}"
   type = "ingress"
   from_port = 5432
@@ -17,6 +21,8 @@ resource "aws_security_group_rule" "inbound_postgres" {
 }
 
 resource "aws_security_group" "openregister" {
+  count = "${signum(var.instance_count)}"
+
   name = "${var.vpc_name}-${var.id}-openregister-sg"
   description = "Openregister EC2 Instance security group"
   vpc_id = "${var.vpc_id}"
@@ -28,6 +34,8 @@ resource "aws_security_group" "openregister" {
 }
 
 resource "aws_security_group_rule" "inbound_ssh" {
+  count = "${signum(var.instance_count)}"
+
   security_group_id = "${aws_security_group.openregister.id}"
   type = "ingress"
   from_port = 22
@@ -37,6 +45,8 @@ resource "aws_security_group_rule" "inbound_ssh" {
 }
 
 resource "aws_security_group_rule" "inbound_http" {
+  count = "${signum(var.instance_count)}"
+
   security_group_id = "${aws_security_group.openregister.id}"
   type = "ingress"
   from_port = 80
@@ -46,6 +56,8 @@ resource "aws_security_group_rule" "inbound_http" {
 }
 
 resource "aws_security_group_rule" "outbound_dns" {
+  count = "${signum(var.instance_count)}"
+
   security_group_id = "${aws_security_group.openregister.id}"
   type = "egress"
   from_port = 53
@@ -55,6 +67,8 @@ resource "aws_security_group_rule" "outbound_dns" {
 }
 
 resource "aws_security_group_rule" "outbound_http" {
+  count = "${signum(var.instance_count)}"
+
   security_group_id = "${aws_security_group.openregister.id}"
   type = "egress"
   from_port = 80
@@ -64,6 +78,8 @@ resource "aws_security_group_rule" "outbound_http" {
 }
 
 resource "aws_security_group_rule" "outbound_https" {
+  count = "${signum(var.instance_count)}"
+
   security_group_id = "${aws_security_group.openregister.id}"
   type = "egress"
   from_port = 443
@@ -73,6 +89,8 @@ resource "aws_security_group_rule" "outbound_https" {
 }
 
 resource "aws_security_group_rule" "outbound_postgres" {
+  count = "${signum(var.instance_count)}"
+
   security_group_id = "${aws_security_group.openregister.id}"
   type = "egress"
   from_port = 5432

--- a/aws/modules/register_group/instance_security_group.tf
+++ b/aws/modules/register_group/instance_security_group.tf
@@ -28,7 +28,7 @@ resource "aws_security_group" "openregister" {
   vpc_id = "${var.vpc_id}"
 
   tags = {
-    Name = "${var.id}-sg"
+    Name = "${var.vpc_name}-${var.id}-sg"
     Environment = "${var.vpc_name}"
   }
 }


### PR DESCRIPTION
Terraform `modules` don't have a `count` parameter. This means we end up
having to set `count`s on all resources inside a module if the module
can be turned on and off (for example how the address register is).