### PR TITLE
Add register field to log entries to make the register name explicit

### DIFF
--- a/ansible/roles/openregister_config/templates/openregister-config.yaml.j2
+++ b/ansible/roles/openregister_config/templates/openregister-config.yaml.j2
@@ -63,7 +63,7 @@ logging:
   appenders:
     - type: console
       target: stdout
-      logFormat: "%-5p [%d{ISO8601}] %X{register} %c: %m %replace(%rEx){'\n',' '}%nopex%n"
+      logFormat: "%-5p [%d{ISO8601}] [Register: %X{register}] %c: %m %replace(%rEx){'\n',' '}%nopex%n"
 
 {% if loop.length > 1 %}
 registers:


### PR DESCRIPTION
This PR simply wraps the register name so that it can be easily searched for in logs