### PR TITLE
Enable confirmation servers for StatusCake tests

### DIFF
--- a/aws/modules/register/availability_checks.tf
+++ b/aws/modules/register/availability_checks.tf
@@ -5,6 +5,7 @@ resource "statuscake_test" "home" {
   test_type = "HTTP"
   check_rate = 60
   contact_id = 55280
+  confirmations = 1
 }
 
 resource "statuscake_test" "records" {
@@ -14,4 +15,5 @@ resource "statuscake_test" "records" {
   test_type = "HTTP"
   check_rate = 60
   contact_id = 55280
+  confirmations = 1
 }


### PR DESCRIPTION
By default StatusCake uses 2 confirmation servers in order to trigger
downtime events. It's only been since Terraform 0.8.5 that this option
has been exposed. Prior to Terraform 0.8.5 this was set to 0 which
meant caused downtime events that only one StatusCake node saw.

This doesn't feel ideal as I'd like to see StatusCake be more reliable
but I think this should give us additional confidence that when alerts
fire our service is really down.