### PR TITLE
Set SOA negative cache TTL to one hour

### DIFF
--- a/aws/modules/core/route53.tf
+++ b/aws/modules/core/route53.tf
@@ -18,6 +18,14 @@ resource "aws_route53_record" "zone_delegation" {
   records = [ "${aws_route53_zone.core.name_servers}" ]
 }
 
+resource "aws_route53_record" "soa" {
+  zone_id = "${aws_route53_zone.core.zone_id}"
+  name = "${var.vpc_name}.${var.dns_domain}"
+  type = "SOA"
+  ttl = "900"
+  records = [ "${aws_route53_zone.core.name_servers.0}. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 ${var.soa_negative_cache_ttl}" ]
+}
+
 resource "aws_route53_zone" "private" {
   name = "${var.vpc_name}.openregister"
   vpc_id = "${aws_vpc.registers.id}"

--- a/aws/modules/core/variables.tf
+++ b/aws/modules/core/variables.tf
@@ -43,3 +43,8 @@ variable "dns_parent_zone_id" {
 }
 
 variable "sumologic_key" {}
+
+variable "soa_negative_cache_ttl" {
+  default = 3600
+  description = "The length of time `NXDOMAIN` responses from our authoritative nameservers should be cached by recursors for"
+}


### PR DESCRIPTION
Without this a `NXDOMAIN` response will be cached by recursors for 24
hours. Given we're hoping to add registers fairly regularly (which will
require new subdomains) it seems sensible to keep this short in order to
avoid the case where someone accidentally(?) tries to resolve a new
register before the records have been created.

The `name-server` field is being set to the first name server in the
list of name servers the hosted zone uses. This is likely to be
different from the value created by AWS, however, it should be
acceptable to set it to any name server that responds authoritatively
for the domain

See: http://www.zytrax.com/books/dns/ch8/soa.html