### PR TITLE
Manage CloudFront with Terraform

### DIFF
--- a/aws/modules/register/availability_checks.tf
+++ b/aws/modules/register/availability_checks.tf
@@ -1,5 +1,5 @@
 resource "statuscake_test" "home" {
-  count = "${var.enable_availability_checks && var.enabled ? 1 : 0}"
+  count = "${var.enabled && var.enable_availability_checks ? 1 : 0}"
   website_name = "${var.environment} - ${var.name} - home"
   website_url = "https://${aws_route53_record.record.fqdn}"
   test_type = "HTTP"
@@ -9,9 +9,29 @@ resource "statuscake_test" "home" {
 }
 
 resource "statuscake_test" "records" {
-  count = "${var.enable_availability_checks && var.enabled ? 1 : 0}"
+  count = "${var.enabled && var.enable_availability_checks ? 1 : 0}"
   website_name = "${var.environment} - ${var.name} - records"
   website_url = "https://${aws_route53_record.record.fqdn}/records"
+  test_type = "HTTP"
+  check_rate = 60
+  contact_id = 55280
+  confirmations = 1
+}
+
+resource "statuscake_test" "cdn_home" {
+  count = "${var.enabled && var.cdn_configuration["enabled"] && var.enable_availability_checks ? 1 : 0}"
+  website_name = "${var.environment} - ${var.name} (gov.uk) - home"
+  website_url = "https://${var.name}.${var.cdn_configuration["domain"]}"
+  test_type = "HTTP"
+  check_rate = 60
+  contact_id = 55280
+  confirmations = 1
+}
+
+resource "statuscake_test" "cdn_records" {
+  count = "${var.enabled && var.cdn_configuration["enabled"] && var.enable_availability_checks ? 1 : 0}"
+  website_name = "${var.environment} - ${var.name} (gov.uk) - records"
+  website_url = "https://${var.name}.${var.cdn_configuration["domain"]}/records"
   test_type = "HTTP"
   check_rate = 60
   contact_id = 55280

--- a/aws/modules/register/cdn.tf
+++ b/aws/modules/register/cdn.tf
@@ -1,0 +1,56 @@
+resource "aws_cloudfront_distribution" "distribution" {
+  count = "${var.enabled && var.cdn_configuration["enabled"] ? 1 : 0}"
+
+  aliases = ["${var.name}.${var.cdn_configuration["domain"]}"]
+  enabled = true
+  http_version = "http1.1"
+  price_class = "PriceClass_100"
+
+  viewer_certificate {
+    iam_certificate_id = "${var.cdn_configuration["certificate_id"]}"
+    ssl_support_method = "sni-only"
+    minimum_protocol_version = "TLSv1"
+  }
+
+  default_cache_behavior {
+    allowed_methods = ["HEAD", "GET"]
+    cached_methods = ["HEAD", "GET"]
+
+    default_ttl = 86400
+    max_ttl = 31536000
+    min_ttl = 0
+
+    forwarded_values {
+      cookies {
+        forward = "none"
+      }
+      query_string = true
+      headers = ["Accept", "Host", "Origin"]
+    }
+
+    target_origin_id = "${var.environment}-${var.name}-elb"
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  origin {
+    domain_name = "${aws_route53_record.record.fqdn}"
+    origin_id = "${var.environment}-${var.name}-elb"
+    custom_origin_config {
+      http_port = 80
+      https_port = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols = ["TLSv1", "TLSv1.1", "TLSv1.2"]
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  logging_config {
+    bucket = "${var.cdn_configuration["logging_bucket"]}.s3.amazonaws.com"
+    prefix = "${var.name}"
+  }
+}

--- a/aws/modules/register/variables.tf
+++ b/aws/modules/register/variables.tf
@@ -20,5 +20,10 @@ variable load_balancer {
 }
 
 variable enable_availability_checks {
-  description = "should availability checks be enabled for this register"
+  description = "should availability checks be enabled for this register?"
+}
+
+variable cdn_configuration {
+  type = "map"
+  description = "should register be fronted by a CDN?"
 }

--- a/aws/registers/registers.tf
+++ b/aws/registers/registers.tf
@@ -8,6 +8,7 @@ module "address_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "academy-school-eng_register" {
@@ -20,6 +21,7 @@ module "academy-school-eng_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "company_register" {
@@ -32,6 +34,7 @@ module "company_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "country_register" {
@@ -44,6 +47,7 @@ module "country_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "datatype_register" {
@@ -56,6 +60,7 @@ module "datatype_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "diocese_register" {
@@ -68,6 +73,7 @@ module "diocese_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "field_register" {
@@ -80,6 +86,7 @@ module "field_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "food-authority_register" {
@@ -92,6 +99,7 @@ module "food-authority_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "food-premises_register" {
@@ -104,6 +112,7 @@ module "food-premises_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "food-premises-rating_register" {
@@ -116,6 +125,7 @@ module "food-premises-rating_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "food-premises-type_register" {
@@ -128,6 +138,7 @@ module "food-premises-type_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "government-domain_register" {
@@ -140,6 +151,7 @@ module "government-domain_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "industry_register" {
@@ -152,6 +164,7 @@ module "industry_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "jobcentre_register" {
@@ -164,6 +177,7 @@ module "jobcentre_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "la-maintained-school-eng_register" {
@@ -176,6 +190,7 @@ module "la-maintained-school-eng_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "local-authority-eng_register" {
@@ -188,6 +203,7 @@ module "local-authority-eng_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "local-authority-nir_register" {
@@ -200,6 +216,7 @@ module "local-authority-nir_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "local-authority-sct_register" {
@@ -212,6 +229,7 @@ module "local-authority-sct_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "local-authority-type_register" {
@@ -224,6 +242,7 @@ module "local-authority-type_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "local-authority-wls_register" {
@@ -236,6 +255,7 @@ module "local-authority-wls_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "notifiable-animal-disease" {
@@ -248,6 +268,7 @@ module "notifiable-animal-disease" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "notifiable-animal-disease-investigation-category" {
@@ -260,6 +281,7 @@ module "notifiable-animal-disease-investigation-category" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "place_register" {
@@ -272,6 +294,7 @@ module "place_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "premises_register" {
@@ -284,6 +307,7 @@ module "premises_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "prison_register" {
@@ -296,6 +320,7 @@ module "prison_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "register_register" {
@@ -308,6 +333,7 @@ module "register_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "religious-character_register" {
@@ -320,6 +346,7 @@ module "religious-character_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "school-admissions-policy_register" {
@@ -332,6 +359,7 @@ module "school-admissions-policy_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "school-authority-eng_register" {
@@ -344,6 +372,7 @@ module "school-authority-eng_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "school-eng_register" {
@@ -356,6 +385,7 @@ module "school-eng_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "school-gender_register" {
@@ -368,6 +398,7 @@ module "school-gender_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "school-phase_register" {
@@ -380,6 +411,7 @@ module "school-phase_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "school-tag_register" {
@@ -392,6 +424,7 @@ module "school-tag_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "school-trust_register" {
@@ -404,6 +437,7 @@ module "school-trust_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "school-type_register" {
@@ -416,6 +450,7 @@ module "school-type_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "street_register" {
@@ -428,6 +463,7 @@ module "street_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "street-custodian_register" {
@@ -440,6 +476,7 @@ module "street-custodian_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "territory_register" {
@@ -452,6 +489,7 @@ module "territory_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }
 
 module "uk_register" {
@@ -464,4 +502,5 @@ module "uk_register" {
   dns_zone_id = "${module.core.dns_zone_id}"
 
   enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
 }

--- a/aws/registers/variables.tf
+++ b/aws/registers/variables.tf
@@ -87,3 +87,10 @@ variable "sumologic_key" {
 }
 
 variable "enable_availability_checks" {}
+
+variable "cdn_configuration" {
+  type = "map"
+  default = {
+    enabled = false
+  }
+}


### PR DESCRIPTION
We'll need to make liberal use of `terraform import module.<register>_register.aws_cloudfront_distribution.distribution <ID>` so that we can (hopefully) seamlessly transition from our manually configured CloudFront distributions.

We don't currently have a test environment that has CloudFront so it might be sensible to `apply` to each distribution one-at-a-time.

This gets us pretty close to managing `register.gov.uk` with Terraform but I don't want to get too distracted because this is just refactoring as part of a separate story.