### PR TITLE
Use only the latest TLS version to connect to the origin

### DIFF
--- a/aws/modules/register/cdn.tf
+++ b/aws/modules/register/cdn.tf
@@ -39,7 +39,7 @@ resource "aws_cloudfront_distribution" "distribution" {
       http_port = 80
       https_port = 443
       origin_protocol_policy = "https-only"
-      origin_ssl_protocols = ["TLSv1", "TLSv1.1", "TLSv1.2"]
+      origin_ssl_protocols = ["TLSv1.2"]
     }
   }
 


### PR DESCRIPTION
This should not affect the viewer TLS configuration which is still TLSv1
as a minimum