### PR TITLE
Use HTTP2 at the edge

### DIFF
--- a/aws/modules/register/cdn.tf
+++ b/aws/modules/register/cdn.tf
@@ -3,7 +3,7 @@ resource "aws_cloudfront_distribution" "distribution" {
 
   aliases = ["${var.name}.${var.cdn_configuration["domain"]}"]
   enabled = true
-  http_version = "http1.1"
+  http_version = "http2"
   price_class = "PriceClass_100"
 
   viewer_certificate {


### PR DESCRIPTION
> HTTP/2 is enabled by default for all new Amazon CloudFront
> distributions, and for existing distributions HTTP/2 can be enabled by
> editing the distribution configuration. There is no additional charge
> for using this feature, and clients that do not support HTTP/2 will
> still be able to communicate with HTTP/2-Enabled Amazon CloudFront
> distributions using HTTP/1.1.

Source: https://aws.amazon.com/about-aws/whats-new/2016/09/amazon-cloudfront-now-supports-http2/