### PR TITLE
Add missing `/` prefix

### DIFF
--- a/aws/modules/register/cdn.tf
+++ b/aws/modules/register/cdn.tf
@@ -68,7 +68,7 @@ resource "aws_cloudfront_distribution" "distribution" {
   origin {
     domain_name = "${var.cdn_configuration["robots_bucket"]}.s3.amazonaws.com"
     origin_id = "${var.environment}-${var.name}-robots-txt"
-    origin_path = "${var.name}"
+    origin_path = "/${var.name}"
 
     s3_origin_config = {
       origin_access_identity = "${var.cdn_s3_origin_access_identity}"


### PR DESCRIPTION
> Origin Path
>
> If you want CloudFront to request your content from a directory in your
> Amazon S3 bucket or your custom origin, enter the directory path,
> beginning with a /. CloudFront appends the directory path to the value
> of Origin Domain Name, for example,
> cf-origin.example.com/production/images. Do not add a / at the end of
> the path.

Source: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValuesOriginPath