### PR TITLE
migrate some of our instances to ubuntu

### DIFF
--- a/aws/modules/register_group/instance.tf
+++ b/aws/modules/register_group/instance.tf
@@ -1,9 +1,13 @@
+data "template_file" "old_user_data" {
+  template = "${file("${path.module}/old-users.yaml")}"
+}
+
 resource "aws_instance" "instance" {
   count = "${var.instance_count}"
-  ami = "${var.instance_ami}"
+  ami = "${element(list(var.instance_ami,"ami-c51e3eb6"), count.index)}"
   instance_type = "${var.instance_type}"
   subnet_id = "${element(var.subnet_ids, count.index)}"
-  user_data = "${var.user_data}"
+  user_data = "${element(list(var.user_data, data.template_file.old_user_data.rendered), count.index)}"
   vpc_security_group_ids = [ "${aws_security_group.openregister.id}" ]
   iam_instance_profile = "${aws_iam_instance_profile.instance_profile.name}"
 

--- a/aws/modules/register_group/old-users.yaml
+++ b/aws/modules/register_group/old-users.yaml
@@ -40,9 +40,10 @@ users:
     sudo: ALL=(ALL) NOPASSWD:ALL
 
 packages:
-  - awscli
-  - docker.io
+  - aws-cli
+  - docker
   - ruby
+  - yum-cron
 
 package_upgrade: true
 
@@ -55,7 +56,89 @@ write_files:
     aws s3 cp s3://aws-codedeploy-eu-west-1/latest/install /tmp/install --region eu-west-1
     chmod +x /tmp/install
     /tmp/install auto
+- path: /etc/yum/yum-cron.conf
+  permissions: '0644'
+  content: |
+    [commands]
+    # 'security' means run command `yum --security upgrade`
+    update_cmd = security
+
+    update_messages = yes
+    download_updates = yes
+    apply_updates = yes
+
+    # Maximum amout of time to randomly sleep, in minutes.  The program
+    # will sleep for a random amount of time between 0 and random_sleep
+    # minutes before running.  This is useful for e.g. staggering the
+    # times that multiple systems will access update servers.  If
+    # random_sleep is 0 or negative, the program will run immediately.
+    #  NOTE that we hold up all the other things in cron.daily as we wait,
+    # so while waiting for 6+ hours is fine for us it might not be nice
+    # for logrotate (so wait for 2 hours by default).
+    random_sleep = 120
+
+
+    [emitters]
+    # Name to use for this system in messages that are emitted.  If
+    # system_name is None, the hostname will be used.
+    system_name = None
+
+    emit_via = stdio
+
+    # The width, in characters, that messages that are emitted should be
+    # formatted to.
+    output_width = 80
+
+
+    [groups]
+    # NOTE: This only works when group_command != objects, which is now the default
+    # List of groups to update
+    group_list = None
+
+    # The types of group packages to install
+    group_package_types = mandatory, default
+
+    [base]
+    # This section overrides yum.conf
+
+    # Use this to filter Yum core messages
+    # -4: critical
+    # -3: critical+errors
+    # -2: critical+errors+warnings (default)
+    debuglevel = -2
+
+    # skip_broken = True
+    mdpolicy = group:main
+- path: /etc/yum/yum-cron-hourly.conf
+  permissions: '0644'
+  content: |
+    [commands]
+    update_cmd = security
+
+    update_messages = no
+    download_updates = no
+    apply_updates = no
+    random_sleep = 0
+
+    [emitters]
+    system_name = None
+    emit_via = None
+
+
+    [groups]
+    group_list = None
+
+    group_package_types = mandatory, default
+
+    [base]
+    debuglevel = -2
+
+    mdpolicy = group:main
+
 
 runcmd:
+  - [ service, yum-cron, start ]
+  - [ chkconfig, yum-cron, on ]
   - [ service, docker, start ]
+  - [ chkconfig, docker, on ]
   - [ /usr/local/bin/setup-cdagent.sh ]

--- a/aws/modules/register_group/variables.tf
+++ b/aws/modules/register_group/variables.tf
@@ -13,7 +13,7 @@ variable "vpc_id" {
 }
 
 variable "instance_ami" {
-  default = "ami-c51e3eb6"
+  default = "ami-98ecb7fe"
   description = "AMI to use for the register EC2 instances"
 }
 

--- a/aws/registers/templates/users.yaml
+++ b/aws/registers/templates/users.yaml
@@ -37,6 +37,8 @@ packages:
   - awscli
   - docker.io
   - ruby
+  - update-notifier-common # required for automatic reboots
+  - unattended-upgrades
 
 package_upgrade: true
 
@@ -49,6 +51,27 @@ write_files:
     aws s3 cp s3://aws-codedeploy-eu-west-1/latest/install /tmp/install --region eu-west-1
     chmod +x /tmp/install
     /tmp/install auto
+- path: /etc/apt/apt.conf.d/50unattended-upgrades
+  permissions: '0644'
+  content: |
+    // Automatically upgrade packages from these (origin:archive) pairs
+    Unattended-Upgrade::Allowed-Origins {
+            "${distro_id}:${distro_codename}";
+            "${distro_id}:${distro_codename}-security";
+    //      "${distro_id}:${distro_codename}-updates";
+    //      "${distro_id}:${distro_codename}-proposed";
+    //      "${distro_id}:${distro_codename}-backports";
+    };
+
+    // List of packages to not update (regexp are supported)
+    Unattended-Upgrade::Package-Blacklist {
+    //      "vim";
+    //      "libc6";
+    //      "libc6-dev";
+    //      "libc6-i686";
+    };
+    
+    Unattended-Upgrade::Automatic-Reboot "true";
 
 runcmd:
   - [ service, docker, start ]

--- a/aws/registers/templates/users.yaml
+++ b/aws/registers/templates/users.yaml
@@ -3,12 +3,6 @@
 users:
   - default
 
-  - name: chrisduraj
-    groups: users
-    ssh-authorized-keys:
-      - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCVVhDnVJvuYocL64Vu6Pr+AJRRrp15UciKpbSsvplhw5l5oc1yvB/+a4oi6AGZZUu66Gk7FGS2f3ESQBP5yPPkKJS+SHACjTqNpGD9OwMb4hRdAiK14gEn5CJDeGF/6gnG31vWeh9ZHlzU0TEfIICIpZ1ojYJu8YM+cuhuuXHIknK9iDngGDIlbhbqA57hts5IsqdktwZgDlJe1h2F/QbU1/+xadjrR7v+tCDhUlw52zHvgeW5hCqnG24Px7zea5eYkShmMjVKtqpJqZWfKaxPaYnJRpbtKpT8L3IyIWdagemxiPsgyG5LglrMdlxRDl9CHUtyBDeMLm23wkWrWQn0LKe07qhUltWvg4UXI8x5j7NzKATNIPB7BTbeQyMbgiGHEWloy9dkJBuNQKSUFQyolFG6lj9z+ea6w80q7f9Of9ylXtaNGWHuP253fSUwU+5mjYaSuQcI7rqk0rU2I6QT1NEXmtM3SPDkNDUfDDrN6d2HYpOHCbzqS0ygH2uVYrfPPG3Unef35MVSIA0KAxpXhoWTNg/pZ2hh+y3YbFKclVqXFFy3R8ka39LKTn+NYWW1Dsb/81EjeTxcfRLKzUTED+Wu5n/Trb0q0YYJld1Hyye9UL0fJ91oEm79AN0+TQXNMemxyIwuqYSruF787eLHcb7mqs9ACiEqkIytCGMXaQ== christopherduraj@gmail.com
-    sudo: ALL=(ALL) NOPASSWD:ALL
-
   - name: philandstuff
     groups: users
     ssh-authorized-keys:


### PR DESCRIPTION
This migrates some of our instances to ubuntu.  Specifically, the
even-numbered instances, when numbering from 0 (so where we have 3
instances, the first and last instance will be migrated to ubuntu).

This only migrates some of the instances so that we don't cause
downtime through this migration.  Once this has been deployed
everywhere, we can go back and migrate the rest.

Our user data (in users.yaml) needed very little changes to support
this.  All I did was:

 - rename some packages which are named differently on ubuntu (aws-cli
   to awscli, docker to docker.io)
 - remove yum-cron and its config (we have a card to reinstate
   ubuntu's equivalent)

I've preserved the original user data as
modules/register_group/old-users.yaml, to support keeping the old
Amazon Linux instances around.

Once this is merged, the remaining tasks are:

 - deploy this everywhere
 - migrate the bastion host
 - migrate the remaining register_group instances
 - clean up the interim code (ie remove old-users.yaml and the
   `element(list(...), count.index)` hacks in this commit)