### PR TITLE
Specify instance image via aws_ami resource

### DIFF
--- a/aws/registers/main.tf
+++ b/aws/registers/main.tf
@@ -9,6 +9,15 @@ provider "statuscake" {
   apikey = "${var.statuscake_apikey}"
 }
 
+data "aws_ami" "ubuntu-xenial-ebs-ssd" {
+  most_recent = true
+  filter {
+    name = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-xenial*"]
+  }
+  owners = ["099720109477"] # canonical account
+}
+
 module "core" {
   source = "../modules/core"
   vpc_name = "${var.vpc_name}"

--- a/aws/registers/main.tf
+++ b/aws/registers/main.tf
@@ -23,6 +23,7 @@ module "core" {
   vpc_name = "${var.vpc_name}"
   vpc_cidr_block = "${var.vpc_cidr_block}"
   public_cidr_blocks = "${var.public_cidr_blocks}"
+  bastion_instance_ami = "${data.aws_ami.ubuntu-xenial-ebs-ssd.image_id}"
   bastion_user_data = "${file("templates/users.yaml")}"
   admin_ips = "${var.admin_ips}"
   sumologic_key = "${var.sumologic_key}"

--- a/aws/registers/register_group_address.tf
+++ b/aws/registers/register_group_address.tf
@@ -3,6 +3,7 @@ module "address" {
   id = "address"
   instance_count = "${lookup(var.group_instance_count, "address", 0)}"
   instance_type = "${lookup(var.group_instance_type, "address", "t2.large")}"
+  instance_ami = "${data.aws_ami.ubuntu-xenial-ebs-ssd.image_id}"
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"

--- a/aws/registers/register_group_basic.tf
+++ b/aws/registers/register_group_basic.tf
@@ -3,6 +3,7 @@ module "basic" {
   id = "basic"
   instance_count = "${lookup(var.group_instance_count, "basic", 0)}"
   instance_type = "${lookup(var.group_instance_type, "basic", "t2.medium")}"
+  instance_ami = "${data.aws_ami.ubuntu-xenial-ebs-ssd.image_id}"
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"

--- a/aws/registers/register_group_multi.tf
+++ b/aws/registers/register_group_multi.tf
@@ -3,6 +3,7 @@ module "multi" {
   id = "multi"
   instance_count = "${lookup(var.group_instance_count, "multi", 0)}"
   instance_type = "${lookup(var.group_instance_type, "multi", "t2.medium")}"
+  instance_ami = "${data.aws_ami.ubuntu-xenial-ebs-ssd.image_id}"
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"


### PR DESCRIPTION
This commit specifies the instance image via the aws_ami resource.
This has the following advantages:

  - it makes it clearer which ami we're using, and what specific
    properties we want (in this case, ubuntu xenial on hvm with ssd
    storage)
  - it will automatically use newer AMIs when they become available

This has the following disadvantage:

  - it will automatically use newer AMIs when they become available

ie, when a new ubuntu AMI gets baked, this code will automatically
rebuild the world to use it.

Putting this out as a PR for discussion; I'm undecided about it.