### PR TITLE
manage our own cloudtrail

### DIFF
--- a/aws/cloudtrail/main.tf
+++ b/aws/cloudtrail/main.tf
@@ -2,10 +2,53 @@ provider "aws" {
   region = "eu-west-1"
 }
 
-module "aws-security-alarms" {
-  source                      = "git::github.com/alphagov/aws-security-alarms.git//terraform?ref=89c8f28c16b91f06cc4aa5765786614653cc9d57"
-  cloudtrail_s3_bucket_name   = "cloudtrail-logs-openregister"
-  cloudtrail_s3_bucket_prefix = "prod"
+data "aws_caller_identity" "current" {}
+
+resource "aws_cloudtrail" "cloudtrail" {
+  name = "CloudTrail-all-regions"
+  enable_log_file_validation = true
+  s3_bucket_name = "${aws_s3_bucket.local-bucket.id}"
+  s3_key_prefix = "prod"
+  include_global_service_events = true
+  is_multi_region_trail = true
+}
+
+resource "aws_s3_bucket" "local-bucket" {
+  bucket = "cloudtrail-logs-openregister"
+  force_destroy = true
+  versioning = {
+    enabled = true
+  }
+  policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AWSCloudTrailAclCheck",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "cloudtrail.amazonaws.com"
+            },
+            "Action": "s3:GetBucketAcl",
+            "Resource": "arn:aws:s3:::cloudtrail-logs-openregister"
+        },
+        {
+            "Sid": "AWSCloudTrailWrite",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "cloudtrail.amazonaws.com"
+            },
+            "Action": "s3:PutObject",
+            "Resource": "arn:aws:s3:::cloudtrail-logs-openregister/prod/AWSLogs/${data.aws_caller_identity.current.account_id}/*",
+            "Condition": {
+                "StringEquals": {
+                    "s3:x-amz-acl": "bucket-owner-full-control"
+                }
+            }
+        }
+    ]
+}
+POLICY
 }
 
 module "ship-to-central-bucket" {


### PR DESCRIPTION
it's not possible to have two instances of the aws-security-alarms
module, because they conflict with each other.

It's not clear that it's valuable for us to do this anyway; we didn't
need most of the functionality and it's probably simpler to manage the
S3 bucket and cloudtrail ourselves.

This works with an appropriate `terraform state mv` command to shift
the S3 bucket and cloudtrail resources.