### PR TITLE
Use `/bin/bash` as our users' login shell

### DIFF
--- a/aws/registers/templates/users.yaml
+++ b/aws/registers/templates/users.yaml
@@ -8,36 +8,42 @@ users:
     ssh-authorized-keys:
       - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDpD0Wc0pfD5NrV0D7alwOZDIqC9id+RroF2BQ59wLqxvF4wvlgtab0VHiIylSeN4K2bK5ikugy6/rwhWWdoQ3raMXIgOWP6ukSh/OLUioxCeop04IlF4JgUo3uNoInkUegnLw42sg/cKX+pbv/1Rc4GEO6J0Wy6YylyeieAWiy2rwgO/nr/49Tyiw1C66embmglhv7OaZEthpKyM3u6rlJeeU0H2K/bsc9yU/Utpek0hx/nih8qlVEPG7/3welWUNb/LwFC4EpJKiU72mRcjWGh9l5MjCJ2SR/wimY1AHQ4YES3VeAQvcaTKMCnaBET/RhnashxMr0f3V7IDkg56tZ cardno:000603815000
     sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
 
   - name: michaelabenyohai
     groups: users
     ssh-authorized-keys:
       - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDBWdzo8bSa/jm95AtgkRmIOMOxXt6sBtA/s6tkQ4R5I+ZM+jK0Gpf+AuIwzlNMIZjNXnH9FeX0Grm+gGK+wRUSbjRMkzoAl3fJhwDII5XY375aiz8VcuLEwW0n4/tGu1qKB3UlB67etxdHBksrgNFEJPA3/EzOizuugVFC396dUIzWEBVFJ6fY/LIlaBnQWkO5lT7+t+PnoBG5dPNslDEYgfp/+p9MxgAX/kzSpEzc1qrtcTwzZHMaO7F5Qix2+QeZ4GTDY3kuDnYbHKRXFHN9lOYoUxHLjXiRNiyqxx5Z+d7QQE76sxidt7d5//amJY6F3KQzXqpJqfbXfJ0ZPFE33BS5SAZx+o/6oE35yays8DjGT98piOGKko0OtCZYM2wiv+d51KMKIU+BFKv9ZxDlMLr/hQulTtjR3BaAWDfLISzaB1N5qqinYXbmEV31z/ymcYGK2LHpV4nIs60ph2CFLzB+nr4eUmf7AbK9IPmYnCnj6JRFwvF7JYsDcNurDcfzkt+dponq2jJnH2SeEjghS1BW+cif8xJtXCdz2i1P6i/ISt19Enwck6iHJ5FjT6zamupp2Lpp+1sFBKoKX60ILGeUQMAzDjCV1mCUhzh8mu9cmf7LGahht+PCX7zBB4NTt5fOYo7uSW1AFB0sPaZwMlFmeO9G7e/5Feq8sXqBvQ== michaelabenyohai
     sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
 
   - name: endamccormack
     groups: users
     ssh-authorized-keys:
       - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDUXIDMVdw5yLzztOiIw8ZfPP1QO8+Auh+TK2+hpe0OAkUt7ifc+hoCeN/eJpvANTR019AqWEQ/OBoUyXE/lDbctvjkqxXTMD8iaQRtC2L3a09rSenh8qTgFWsLrd3sFnXPbYmQL1kUqnwDXLaw882Q+jPZXCEzowN8NNcSOB3ZrHvg50B4S6TBdVkwDx1yb9EnqaDRnoBuUPScnXrfB2/ZmWVEiz4m1LWj0yQcuw6YdHljl3l3GrRo78re20rwHXOkHcE7tkSSRankk+Z+aI5qWW/uNoXT0LbiA64QcQDfwrS45wHtUSbZp6pzZ4St7XwJy/HqRqn0IoA0kRDp5wmmjnNqoFBDmjrnLUVxC2iYOz53RlF8CGIMApvYWi1c+yTh3GwPHyYqCWP389KSLduMKIgyiGon11Qgco/75VJTfFHMzwf8sFE0PRe7w8p8irxB4/Khjg6BUdwyFxHbbsVcKiI25Zv3smJgFj2F0lG1yHwvh3cy4JC59MDrkRF4ZWAaakxTcpJOaDHyx8GOVKSBMgIyfDiGrBMx7iNQ6tZxYs8D420w2rA+L2FT+MUyPgaAmgNvEcZ/uxcTaVJnbwn+YfV7KfX3TvRfwLnLCB72qTtG3ZDlF7EmmQFDNy6nI8q+fty9s0cF15b9jnogzE+pPWi8iZI4KltGZaW1BdL03w== enda.mccormack@digital.cabinet-office.gov.uk
     sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
 
   - name: johnollier
     groups: users
     ssh-authorized-keys:
       - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDlClyu95kUpGhMrugnkmpNWre1SUW/KjF1wOIHetFY1VTPiJMeZyTjSufVWzk/fSLwgR2v1D194C4J+C55DohB9vEpkYbZvXsPfD/LpUCBX/YT2/X1s8ZrQzs0q7a1JRmGnQ9PZWHhh3jFJgmnUBNCEo/OHD7E4eLnDlsOurBRFzp9ATUKSD9EUv0sPWvHgqZcocXo7kvNN6/6h7OQGn4utQsdrxjius5EvxOgZWodnlDSxeJ88yK/+sQl5Fg+/XGvv09yraD7qBpO3gRIvOJey5/lb+s3YLgbLbDxggWYMFxCACTpldhblFGGiK6PRxYPkXkOWlPMDXHXtgPV4KH1+fXJpsbBAz7MPMrAWdlOAT2tVaG/xLTRsCUEUVOD3QdAoKG5BGX5mcYxON4WrI1aDe/taUozpCufoF5nXLt5Qv/FtdZgHZzKQLGSr1y2vCG/Tc5JoXTX6h7fFDAaVguVEP68ghhJWlLdTzxwH+YUii8fRdTBiokC4UxcFiVI9spAQDsib/5oOQKLkbjQfPITBZQuHqYrXs2iStOOWlLBUNu1rfXScp2337zunvSxU9Md8hC80A1TMJxZPpBP+IR7eVHlCdlEvaw3Z2MYppg1gFWOSI+LfB8W27Xw1L2HNMNCuT+J+dBAfFYaIYUv+9btlT9l2dtveGUxfAA7ioiRAQ== john.ollier@digital.cabinet-office.gov.uk
     sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
 
   - name: karlbaker
     groups: users
     ssh-authorized-keys:
       - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCo6AI0U+VFs2dkrwNDMKcU7j5lhSPFDuboQrsGyC1tv8aUBlCSfVDaPRPT20lYANN7tFgQD9mKXaMlUd9bCJJFs7L3CbE+/kSQCE85rfPFDaTMb3/WzYzwMjDD05pRtvdBwmkS6o8IFA4Yyd29qahYhnrO3jexBIZnNdM4nWZCac+nX/8bWckPOGWIR7fTNWoS8C8tioiUDqa/ZflzGqA0NKv7M0I1kwKqHt25FHaqZxnGmnKEC9QIUGbS4cC1cJQ2AO3NqJGPWhb39QrZwvv+Juh9rU3vuohDfx7Xm1Lh8NMVf3+c1vNTcK+DvaGGLZJ20JUBXlRRFFviLo9eaaf5fHIn5bM9aKFwxoPZtlj73FQpv04bUJf/LlbnGgLeW+B6Pl2w2qFp3u5p5NtvPEnLLPm4ljiPsJwl6vdmZy/xLc8/Ze0xyOeMaENm9MFK8BykgBqXqmEsSntvryP2fp1LgwDOt9ufLpF+yLq6hXl/JKYDJZiCTUjpwSbO/GRbsf2PCjzcwLxKIru3QtR9IZmiopeYRbDvH6Zofs/4M4mQVlBv15CKthVSTwwvcb9vOQyRa2uRW6FkY//g04+2yXpU742Cuh0CgNUd1fJ/vO3kCO0Fup/m3M0B7Vsr4NE5/0XdZSXOd5sF9oB4uVh9vE7apD0+hGbeQHzXz5cRNn52KQ== karl.alec.baker@gmail.com
     sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
 
   - name: samcrang
     groups: users
     ssh-authorized-keys:
       - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDHtO59/mISjM3EzlKPn3A38IdiJfhGekrR+RLMc9/+AoTFGjmIZRKNDHRHhD4q5GJVEmB9QXxSt0sv4b5ufr3PEJR0DEZ9fKL038nVZyV6OEbSzolif04iFGPHycmRU4zErm5vJyN/FJTxptwkPWlgpyBx4ctFICqtBGAivRqCg3l59icEtOTo94Paz8cFidI1YTolj6hG2KbrZWGG4DGZ6O9CjcSkyYk3BJLxPGLPS8rW/zy1Fp3qXA4q1CCpYi4FQ7o1L8l8OOkBp0Uwq332ijO0pezOt4CyGqMdmITKQpQS2kE1nJpMi9A+Flu/T9ZrgrRgm8NVARlSYUc0QmnQObzMtwmmLhY3K6nesToQraikhnMqpHnmYhtuHH3JYGC7zeLR8RHZqqb7LCLZf4jmNDQbAtCHVgo5sQxw84dZKNKqWIbD1Jbkd9vOoNUM2I/TJQDtwVjzljlWdzIq68q3IKZBJS1x/n35vlyyNaEHSs3TdM0yYnKDukFqWbflzwm7Zl+X1NsuRSAdmShc4jzDGreUm9fRUTY+vtTjbIyo+Sv4nmVmWEjV9NH/DL93m9yKn10ZOOgEp/OFGE/nvapV2v+jz96plC0GCKUgJ/KxFqbxfW6T596bODsqr66553Q+ZjT/yBHzN7tO3T4SXRdn/qQvPkP+yAg76wtPwiFspQ== sam.crang@digital.cabinet-office.gov.uk GPG:B91590AEA3A6B81BCAE99ADC1F07315057BC3A55
     sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
 
 packages:
   - awscli


### PR DESCRIPTION
By default on the Ubuntu Linux AMI a users shell is unspecified and
`/bin/sh` is used. This means tab-completion, scroll-back and a bunch of
other things are broken.