### PR TITLE
reboot newly provisioned instances if required

### DIFF
--- a/aws/registers/templates/users.yaml
+++ b/aws/registers/templates/users.yaml
@@ -48,6 +48,7 @@ packages:
   - unattended-upgrades
 
 package_upgrade: true
+package_reboot_if_required: true
 
 write_files:
 - path: /usr/local/bin/setup-cdagent.sh


### PR DESCRIPTION
If a newly provisioned instance installs a kernel upgrade, it won't
run that until the next reboot.  This commit ensures that the reboot
happens immediately.