### PR TITLE
Improve temporary file removal in script

### DIFF
--- a/scripts/field-load.sh
+++ b/scripts/field-load.sh
@@ -45,9 +45,9 @@ fi
 
 echo ""
 echo "Removing temporary files"
-rm tmp/$FIELD.yaml
-rm $FIELD.rsf
-rm field-records.json
+rm -f tmp/*.yaml
+rm -f $FIELD.rsf
+rm -f field-records.json
 
 echo ""
 echo "Done!"

--- a/scripts/registry-load.sh
+++ b/scripts/registry-load.sh
@@ -46,9 +46,9 @@ fi
 
 echo ""
 echo "Removing temporary files"
-rm tmp/$REGISTER.yaml
-rm $REGISTER.rsf
-rm field-records.json
+rm -f tmp/*.yaml
+rm -f $REGISTER.rsf
+rm -f field-records.json
 
 echo ""
 echo "Done!"


### PR DESCRIPTION
- Use -f flag when removing files to prevent error when file not present.
- Remove all yaml files from tmp directory.