### PR TITLE
Upgrade to Ubuntu 16.10 (Yakkety Yak)

### DIFF
--- a/aws/registers/main.tf
+++ b/aws/registers/main.tf
@@ -9,11 +9,11 @@ provider "statuscake" {
   apikey = "${var.statuscake_apikey}"
 }
 
-data "aws_ami" "ubuntu-xenial-ebs-ssd" {
+data "aws_ami" "ubuntu-hvm-ebs-ssd" {
   most_recent = true
   filter {
     name = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20170202"]
+    values = ["ubuntu/images/hvm-ssd/ubuntu-yakkety-16.10-amd64-server-20170222"]
   }
   owners = ["099720109477"] # canonical account
 }
@@ -23,7 +23,7 @@ module "core" {
   vpc_name = "${var.vpc_name}"
   vpc_cidr_block = "${var.vpc_cidr_block}"
   public_cidr_blocks = "${var.public_cidr_blocks}"
-  bastion_instance_ami = "${data.aws_ami.ubuntu-xenial-ebs-ssd.image_id}"
+  bastion_instance_ami = "${data.aws_ami.ubuntu-hvm-ebs-ssd.image_id}"
   bastion_user_data = "${file("templates/users.yaml")}"
   admin_ips = "${var.admin_ips}"
 }

--- a/aws/registers/register_group_address.tf
+++ b/aws/registers/register_group_address.tf
@@ -3,7 +3,7 @@ module "address" {
   id = "address"
   instance_count = "${lookup(var.group_instance_count, "address", 0)}"
   instance_type = "${lookup(var.group_instance_type, "address", "t2.large")}"
-  instance_ami = "${data.aws_ami.ubuntu-xenial-ebs-ssd.image_id}"
+  instance_ami = "${data.aws_ami.ubuntu-hvm-ebs-ssd.image_id}"
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"

--- a/aws/registers/register_group_basic.tf
+++ b/aws/registers/register_group_basic.tf
@@ -3,7 +3,7 @@ module "basic" {
   id = "basic"
   instance_count = "${lookup(var.group_instance_count, "basic", 0)}"
   instance_type = "${lookup(var.group_instance_type, "basic", "t2.micro")}"
-  instance_ami = "${data.aws_ami.ubuntu-xenial-ebs-ssd.image_id}"
+  instance_ami = "${data.aws_ami.ubuntu-hvm-ebs-ssd.image_id}"
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"

--- a/aws/registers/register_group_multi.tf
+++ b/aws/registers/register_group_multi.tf
@@ -3,7 +3,7 @@ module "multi" {
   id = "multi"
   instance_count = "${lookup(var.group_instance_count, "multi", 0)}"
   instance_type = "${lookup(var.group_instance_type, "multi", "t2.medium")}"
-  instance_ami = "${data.aws_ami.ubuntu-xenial-ebs-ssd.image_id}"
+  instance_ami = "${data.aws_ami.ubuntu-hvm-ebs-ssd.image_id}"
 
   vpc_name = "${var.vpc_name}"
   vpc_id = "${module.core.vpc_id}"


### PR DESCRIPTION
We're going to try using the latest Ubuntu release as opposed to the LTS
release. Rationale is that it keeps us on a modern release and makes
distro upgrades potentially less scary as they're smaller.