### PR TITLE
Send `X-Forwarded-Host` to origin

### DIFF
--- a/aws/modules/register/cdn.tf
+++ b/aws/modules/register/cdn.tf
@@ -57,6 +57,10 @@ resource "aws_cloudfront_distribution" "distribution" {
   origin {
     domain_name = "${aws_route53_record.record.fqdn}"
     origin_id = "${var.environment}-${var.name}-elb"
+    custom_header {
+      name = "X-Forwaded-Host",
+      value = "${var.name}.${var.cdn_configuration["domain"]}"
+    }
     custom_origin_config {
       http_port = 80
       https_port = 443


### PR DESCRIPTION
> The X-Forwarded-Host (XFH) header is a de-facto standard header for
> identifying the original host requested by the client in the Host HTTP
> request header.
>
> Host names and ports of reverse proxies (load balancers, CDNs) may
> differ from the origin server handling the request, in that case the
> X-Forwarded-Host header is useful to determine which Host was originally
> used.
Source: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host

This should allow us to more easily tweak behaviour of registers on
`*.register.gov.uk` and `*.beta.openregister.org`