### PR TITLE
Make `make plan` approximately twice as fast

### DIFF
--- a/aws/cloudtrail/Makefile
+++ b/aws/cloudtrail/Makefile
@@ -5,17 +5,17 @@
 	plan \
 	plan-destroy
 
-export expected_terraform_version=v0.8
-export actual_terraform_version=$(shell terraform version | head -n 1 | cut -f2 -d" " | cut -d"." -f1,2)
+export expected_terraform_version:=v0.8
+export actual_terraform_version:=$(shell terraform version | head -n 1 | cut -f2 -d" " | cut -d"." -f1,2)
 
 ifneq ($(expected_terraform_version), $(actual_terraform_version))
   $(error Expected terraform version $(expected_terraform_version).x, but saw $(actual_terraform_version).x)
 endif
 
-export TF_VAR_central_cloudtrail_bucket_name=$(or $(shell PASSWORD_STORE_DIR=~/.registers-pass pass services/central-cloudtrail-bucket-name | tail -n 1), $(error "Couldn't get central cloudtrail bucket name"))
+export TF_VAR_central_cloudtrail_bucket_name:=$(or $(shell PASSWORD_STORE_DIR=~/.registers-pass pass services/central-cloudtrail-bucket-name | tail -n 1), $(error "Couldn't get central cloudtrail bucket name"))
 
 # Default terraform plan -module-depth= value
-module_depth=-1
+module_depth:=-1
 
 # We don't want any local state being pushed when remote state is
 # configured, so refuse to run if it exists.

--- a/aws/registers/Makefile
+++ b/aws/registers/Makefile
@@ -13,8 +13,8 @@
 	diff-config \
 	push-state
 
-export expected_terraform_version=v0.8
-export actual_terraform_version=$(shell terraform version | head -n 1 | cut -f2 -d" " | cut -d"." -f1,2)
+export expected_terraform_version:=v0.8
+export actual_terraform_version:=$(shell terraform version | head -n 1 | cut -f2 -d" " | cut -d"." -f1,2)
 
 ifneq ($(expected_terraform_version), $(actual_terraform_version))
   $(error Expected terraform version $(expected_terraform_version).x, but saw $(actual_terraform_version).x)
@@ -25,26 +25,26 @@ ifndef vpc
 endif
 
 # Default AWS region
-export AWS_DEFAULT_REGION=eu-west-1
+export AWS_DEFAULT_REGION:=eu-west-1
 
 # RDS master passwords
-export TF_VAR_openregister_database_master_password=$(or $(shell PASSWORD_STORE_DIR=~/.registers-pass pass $(vpc)/rds/openregister/master), $(error "Couldn't get RDS master password from pass"))
+export TF_VAR_openregister_database_master_password:=$(or $(shell PASSWORD_STORE_DIR=~/.registers-pass pass $(vpc)/rds/openregister/master), $(error "Couldn't get RDS master password from pass"))
 
 # StatusCake
-export TF_VAR_statuscake_username=$(or $(shell PASSWORD_STORE_DIR=~/.registers-pass pass services/statuscake/api | tail -n 1), $(error "Couldn't get StatusCake username"))
-export TF_VAR_statuscake_apikey=$(or $(shell PASSWORD_STORE_DIR=~/.registers-pass pass services/statuscake/api | head -n 1), $(error "Couldn't get StatusCake password"))
+export TF_VAR_statuscake_username:=$(or $(shell PASSWORD_STORE_DIR=~/.registers-pass pass services/statuscake/api | tail -n 1), $(error "Couldn't get StatusCake username"))
+export TF_VAR_statuscake_apikey:=$(or $(shell PASSWORD_STORE_DIR=~/.registers-pass pass services/statuscake/api | head -n 1), $(error "Couldn't get StatusCake password"))
 
 # Sumo Logic
-export TF_VAR_sumologic_key=$(or $(shell PASSWORD_STORE_DIR=~/.registers-pass pass services/sumologic/$(vpc)/app-logs | tail -n 1), $(error "Couldn't get Sumo Logic key"))
+export TF_VAR_sumologic_key:=$(or $(shell PASSWORD_STORE_DIR=~/.registers-pass pass services/sumologic/$(vpc)/app-logs | tail -n 1), $(error "Couldn't get Sumo Logic key"))
 
 # InfluxCloud
-export TF_VAR_influxdb_password=$(or $(shell PASSWORD_STORE_DIR=~/.registers-pass pass services/influxcloud/telegraf | tail -n 1), $(error "Couldn't get InfluxCloud password"))
+export TF_VAR_influxdb_password:=$(or $(shell PASSWORD_STORE_DIR=~/.registers-pass pass services/influxcloud/telegraf | tail -n 1), $(error "Couldn't get InfluxCloud password"))
 
 # Required minimum to terraform
-defaults=-var-file=environments/$(vpc).tfvars
+defaults:=-var-file=environments/$(vpc).tfvars
 
 # Default terraform plan -module-depth= value
-module_depth=-1
+module_depth:=-1
 
 # We don't want any local state being pushed when remote state is
 # configured, so refuse to run if it exists.

--- a/aws/sumologic/Makefile
+++ b/aws/sumologic/Makefile
@@ -7,11 +7,11 @@
 	plan-destroy \
 	push-state
 
-export expected_terraform_version=v0.8
-export actual_terraform_version=$(shell terraform version | head -n 1 | cut -f2 -d" " | cut -d"." -f1,2)
+export expected_terraform_version:=v0.8
+export actual_terraform_version:=$(shell terraform version | head -n 1 | cut -f2 -d" " | cut -d"." -f1,2)
 
-export expected_node_version=v7.1.0
-export actual_node_version=$(shell node --version | head -n 1)
+export expected_node_version:=v7.1.0
+export actual_node_version:=$(shell node --version | head -n 1)
 
 ifneq ($(expected_terraform_version), $(actual_terraform_version))
   $(error Expected terraform version $(expected_terraform_version).x, but saw $(actual_terraform_version).x)
@@ -21,13 +21,13 @@ ifneq ($(expected_node_version), $(actual_node_version))
 	$(error Expected node version $(expected_node_version), but saw $(actual_node_version))
 endif
 
-lambda_functions=$(addprefix build/,$(addsuffix .zip,$(wildcard lambda/*)))
+lambda_functions:=$(addprefix build/,$(addsuffix .zip,$(wildcard lambda/*)))
 
-sumologic_cloudfront_key=$(shell PASSWORD_STORE_DIR=~/.registers-pass pass services/sumologic/cloudfront-logs)
-sumologic_cloudtrail_key=$(shell PASSWORD_STORE_DIR=~/.registers-pass pass services/sumologic/cloudtrail-logs)
+sumologic_cloudfront_key:=$(shell PASSWORD_STORE_DIR=~/.registers-pass pass services/sumologic/cloudfront-logs)
+sumologic_cloudtrail_key:=$(shell PASSWORD_STORE_DIR=~/.registers-pass pass services/sumologic/cloudtrail-logs)
 
 # Default terraform plan -module-depth= value
-module_depth=-1
+module_depth:=-1
 
 # We don't want any local state being pushed when remote state is
 # configured, so refuse to run if it exists.

--- a/aws/tls-certs/Makefile
+++ b/aws/tls-certs/Makefile
@@ -9,17 +9,17 @@
 	push-state
 
 # Default AWS region
-export AWS_DEFAULT_REGION=eu-west-1
+export AWS_DEFAULT_REGION:=eu-west-1
 
-export expected_terraform_version=v0.8
-export actual_terraform_version=$(shell terraform version | head -n 1 | cut -f2 -d" " | cut -d"." -f1,2)
+export expected_terraform_version:=v0.8
+export actual_terraform_version:=$(shell terraform version | head -n 1 | cut -f2 -d" " | cut -d"." -f1,2)
 
 ifneq ($(expected_terraform_version), $(actual_terraform_version))
   $(error Expected terraform version $(expected_terraform_version).x, but saw $(actual_terraform_version).x)
 endif
 
 # Default terraform plan -module-depth= value
-module_depth=-1
+module_depth:=-1
 
 # We don't want any local state being pushed when remote state is
 # configured, so refuse to run if it exists.


### PR DESCRIPTION
It turns out that we've been assigning variables in `make` lazily. This
means that all variables are evaluated separately for each target.

For example, a `make plan` uses 4 targets. This means that `pass` is
called 4 times to get the same password. This is unacceptable for us
because decryption operations on `pass` are slow. We can measure this
with this with the following:

```
{ time make plan -e vpc=test } 2>> results.txt
```

Before (mean wall time: ~85s):

```
make plan -e vpc=test  19.60s user 6.60s system 30% cpu 1:26.22 total
make plan -e vpc=test  20.19s user 6.96s system 23% cpu 1:55.05 total
make plan -e vpc=test  19.82s user 6.91s system 29% cpu 1:29.93 total
make plan -e vpc=test  19.45s user 6.47s system 35% cpu 1:13.01 total
make plan -e vpc=test  19.38s user 6.44s system 40% cpu 1:03.06 total
```

After (mean wall time: ~41s):

```
make plan -e vpc=test  15.15s user 4.15s system 42% cpu 44.942 total
make plan -e vpc=test  14.94s user 4.10s system 41% cpu 45.683 total
make plan -e vpc=test  15.01s user 4.13s system 49% cpu 38.784 total
make plan -e vpc=test  15.10s user 4.13s system 48% cpu 39.696 total
make plan -e vpc=test  15.06s user 4.29s system 47% cpu 40.740 total
```