### PR TITLE
Add missing dependency

### DIFF
--- a/aws/sumologic/lambda/cloudtrail-s3-logs-to-sumologic/package.json
+++ b/aws/sumologic/lambda/cloudtrail-s3-logs-to-sumologic/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "aws-sdk": "^2.7.0",
     "byline": "^5.0.0",
+    "request": "^2.79.0",
     "through": "^2.3.8"
   }
 }


### PR DESCRIPTION
I noticed that our CloudTrail logs weren't ending up in Sumo Logic. The Lambda task was failing on invocation as we were missing a required dependency.

All the CloudTrail logs are still ending up in two separate S3 buckets so there's no concern around lack of auditability.