### PR TITLE
Enable docker service

### DIFF
--- a/aws/registers/templates/users.yaml
+++ b/aws/registers/templates/users.yaml
@@ -88,5 +88,6 @@ write_files:
     Unattended-Upgrade::Automatic-Reboot "true";
 
 runcmd:
-  - [ service, docker, start ]
+  - [ systemctl, enable, docker.service ]
+  - [ systemctl, start, docker.service ]
   - [ /usr/local/bin/setup-cdagent.sh ]


### PR DESCRIPTION
In Xenial after installing the `docker.io` package the docker service
was enabled on that machine:

```
$ cat /etc/lsb-release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=16.04
DISTRIB_CODENAME=xenial
DISTRIB_DESCRIPTION="Ubuntu 16.04.2 LTS"
$ sudo apt-get install docker.io
...
$ systemctl list-unit-files | grep docker
docker.service                             enabled
docker.socket                              enabled
```

With Yakkety the service is not enabled by default:

```
$ cat /etc/lsb-release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=16.10
DISTRIB_CODENAME=yakkety
DISTRIB_DESCRIPTION="Ubuntu 16.10"
$ sudo apt-get install docker.io
...
$ systemctl list-unit-files | grep docker
docker.service                         disabled
docker.socket                          enabled
```