### PR TITLE
Upgrade to Terraform 0.9.0

### DIFF
--- a/aws/cloudtrail/Makefile
+++ b/aws/cloudtrail/Makefile
@@ -1,34 +1,19 @@
 .PHONY: all \
-	check-for-local-state \
 	configure-state \
 	destroy \
 	plan \
 	plan-destroy
-
-export expected_terraform_version:=v0.8
-export actual_terraform_version:=$(shell terraform version | head -n 1 | cut -f2 -d" " | cut -d"." -f1,2)
-
-ifneq ($(expected_terraform_version), $(actual_terraform_version))
-  $(error Expected terraform version $(expected_terraform_version).x, but saw $(actual_terraform_version).x)
-endif
 
 export TF_VAR_central_cloudtrail_bucket_name:=$(or $(shell PASSWORD_STORE_DIR=~/.registers-pass pass services/central-cloudtrail-bucket-name | tail -n 1), $(error "Couldn't get central cloudtrail bucket name"))
 
 # Default terraform plan -module-depth= value
 module_depth:=-1
 
-# We don't want any local state being pushed when remote state is
-# configured, so refuse to run if it exists.
-check-for-local-state:
-	@test ! -f terraform.tfstate || true
+purge-remote-state-cache:
+	rm -r .terraform/terraform.tfstate
 
-configure-state: check-for-local-state
-	terraform remote config \
-          -backend=S3 \
-          -backend-config="bucket=registers-cloudtrail-terraform-state" \
-          -backend-config="encrypt=true" \
-          -backend-config="key=cloudtrail.tfstate" \
-          -backend-config="region=eu-west-1"
+configure-state: purge-remote-state-cache
+	terraform init
 
 plan: configure-state
 	terraform plan -module-depth=$(module_depth)

--- a/aws/cloudtrail/main.tf
+++ b/aws/cloudtrail/main.tf
@@ -1,3 +1,13 @@
+terraform {
+  required_version = "~> 0.9.0"
+  backend "s3" {
+    bucket  = "registers-cloudtrail-terraform-state"
+    key = "cloudtrail.tfstate"
+    region = "eu-west-1"
+    encrypt = "true"
+  }
+}
+
 provider "aws" {
   region = "eu-west-1"
 }

--- a/aws/registers/.gitignore
+++ b/aws/registers/.gitignore
@@ -1,0 +1,1 @@
+backend.tf

--- a/aws/registers/Makefile
+++ b/aws/registers/Makefile
@@ -13,13 +13,6 @@
 	diff-config \
 	push-state
 
-export expected_terraform_version:=v0.8
-export actual_terraform_version:=$(shell terraform version | head -n 1 | cut -f2 -d" " | cut -d"." -f1,2)
-
-ifneq ($(expected_terraform_version), $(actual_terraform_version))
-  $(error Expected terraform version $(expected_terraform_version).x, but saw $(actual_terraform_version).x)
-endif
-
 ifndef vpc
   $(error You must pass -e vpc=<name> switch)
 endif
@@ -46,26 +39,22 @@ defaults:=-var-file=environments/$(vpc).tfvars
 # Default terraform plan -module-depth= value
 module_depth:=-1
 
-# We don't want any local state being pushed when remote state is
-# configured, so refuse to run if it exists.
-check-for-local-state: 
-	@test ! -f terraform.tfstate || exit 1
-
 # TODO should also reject defined-but-blank variable
 ifndef TF_VAR_openregister_database_master_password
   $(error TF_VAR_openregister_database_master_password variable is required)
 endif
 
 purge-remote-state-cache: 
-	rm -rf .terraform/terraform.tfstate
+	rm -f backend.tf
+	rm -f .terraform/terraform.tfstate
 
-configure-state: check-for-local-state purge-remote-state-cache
-	terraform remote config \
-          -backend=S3 \
-          -backend-config="bucket=registers-terraform-state" \
-          -backend-config="encrypt=true" \
-          -backend-config="key=$(vpc).tfstate" \
-          -backend-config="region=$(AWS_DEFAULT_REGION)"
+configure-state: purge-remote-state-cache
+	# Hack to make 0.8->0.9 upgrade easy. We should move to using Terraform State
+	# Environments(?).
+	#
+	# https://www.terraform.io/docs/state/environments.html
+	sed -e 's/{{environment}}/$(vpc)/' backend.tf.tmpl > backend.tf
+	terraform init
 
 pull-config:
 	aws s3 cp s3://registers-terraform-config/$(vpc).tfvars environments/$(vpc).tfvars

--- a/aws/registers/backend.tf.tmpl
+++ b/aws/registers/backend.tf.tmpl
@@ -1,0 +1,9 @@
+terraform {
+  required_version = "~> 0.9.0"
+  backend "s3" {
+    bucket = "registers-terraform-state"
+    key = "{{environment}}.tfstate"
+    region = "eu-west-1"
+    encrypt = "true"
+  }
+}

--- a/aws/sumologic/Makefile
+++ b/aws/sumologic/Makefile
@@ -4,18 +4,10 @@
 	configure-state \
 	destroy \
 	plan \
-	plan-destroy \
-	push-state
-
-export expected_terraform_version:=v0.8
-export actual_terraform_version:=$(shell terraform version | head -n 1 | cut -f2 -d" " | cut -d"." -f1,2)
+	plan-destroy
 
 export expected_node_version:=v7.1.0
 export actual_node_version:=$(shell node --version | head -n 1)
-
-ifneq ($(expected_terraform_version), $(actual_terraform_version))
-  $(error Expected terraform version $(expected_terraform_version).x, but saw $(actual_terraform_version).x)
-endif
 
 ifneq ($(expected_node_version), $(actual_node_version))
 	$(error Expected node version $(expected_node_version), but saw $(actual_node_version))
@@ -29,18 +21,11 @@ sumologic_cloudtrail_key:=$(shell PASSWORD_STORE_DIR=~/.registers-pass pass serv
 # Default terraform plan -module-depth= value
 module_depth:=-1
 
-# We don't want any local state being pushed when remote state is
-# configured, so refuse to run if it exists.
-check-for-local-state:
-	@test ! -f terraform.tfstate || true
+purge-remote-state-cache:
+	rm -r .terraform/terraform.tfstate
 
-configure-state: check-for-local-state
-	terraform remote config \
-          -backend=S3 \
-          -backend-config="bucket=registers-cloudfront-terraform-state" \
-          -backend-config="encrypt=true" \
-          -backend-config="key=cloudfront.tfstate" \
-          -backend-config="region=eu-west-1"
+configure-state: purge-remote-state-cache
+	terraform init
 
 plan: configure-state $(lambda_functions)
 	terraform plan -module-depth=$(module_depth)
@@ -61,7 +46,6 @@ build/lambda/%.zip: lambda/%/lambda.js lambda/%/package.json
 
 lambda/cloudfront-s3-logs-to-sumologic/lambda.js: lambda/cloudfront-s3-logs-to-sumologic/cloudfront.js
 	sed -e 's/<XXXX>/$(sumologic_cloudfront_key)/' $< > $@
-
 
 lambda/cloudtrail-s3-logs-to-sumologic/lambda.js: lambda/cloudtrail-s3-logs-to-sumologic/cloudtrail.js
 	sed -e 's/<XXXX>/$(sumologic_cloudtrail_key)/' $< > $@

--- a/aws/sumologic/main.tf
+++ b/aws/sumologic/main.tf
@@ -1,3 +1,13 @@
+terraform {
+  required_version = "~> 0.9.0"
+  backend "s3" {
+    bucket  = "registers-cloudfront-terraform-state"
+    key = "cloudfront.tfstate"
+    region = "eu-west-1"
+    encrypt = "true"
+  }
+}
+
 resource "aws_iam_role_policy" "s3_logs_lambda" {
     name = "s3_logs_lambda"
     role = "${aws_iam_role.lambda.id}"

--- a/aws/tls-certs/Makefile
+++ b/aws/tls-certs/Makefile
@@ -1,44 +1,22 @@
 .PHONY: all \
 	apply \
-	check-for-local-state \
 	configure-state \
 	destroy \
 	plan \
 	plan-destroy \
-	purge-remote-state-cache \
-	push-state
+	purge-remote-state-cache
 
 # Default AWS region
 export AWS_DEFAULT_REGION:=eu-west-1
 
-export expected_terraform_version:=v0.8
-export actual_terraform_version:=$(shell terraform version | head -n 1 | cut -f2 -d" " | cut -d"." -f1,2)
-
-ifneq ($(expected_terraform_version), $(actual_terraform_version))
-  $(error Expected terraform version $(expected_terraform_version).x, but saw $(actual_terraform_version).x)
-endif
-
 # Default terraform plan -module-depth= value
 module_depth:=-1
 
-# We don't want any local state being pushed when remote state is
-# configured, so refuse to run if it exists.
-check-for-local-state: 
-	@test ! -f terraform.tfstate || true
+purge-remote-state-cache:
+	rm -r .terraform/terraform.tfstate
 
-purge-remote-state-cache: 
-	rm -rf .terraform/terraform.tfstate
-
-configure-state: check-for-local-state purge-remote-state-cache
-	terraform remote config \
-          -backend=S3 \
-          -backend-config="bucket=registers-certs-terraform-state" \
-          -backend-config="encrypt=true" \
-          -backend-config="key=tls-certs.tfstate" \
-          -backend-config="region=$(AWS_DEFAULT_REGION)"
-
-push-state:
-	terraform remote push
+configure-state: purge-remote-state-cache
+	terraform init
 
 plan: configure-state
 	terraform plan $(defaults) -module-depth=$(module_depth)

--- a/aws/tls-certs/main.tf
+++ b/aws/tls-certs/main.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = "~> 0.9.0"
+  backend "s3" {
+    bucket  = "registers-certs-terraform-state"
+    key = "tls-certs.tfstate"
+    region = "eu-west-1"
+    encrypt = "true"
+  }
+}


### PR DESCRIPTION
There is some slight ugliness to work around the new backend
configuration in 0.9.0 and the fact it doesn't support interpolations.

In the short-term this means we can upgrade to 0.9.0 and get the
[StatusCake bug fix](https://github.com/hashicorp/terraform/pull/12375) we need without having to change significantly how we
use and deploy Terraform.  We should probably look at using
[Terraform State Environments](https://www.terraform.io/docs/state/environments.html)
instead.