### PR TITLE
Enable ELB connection draining

### DIFF
--- a/aws/modules/register_group/elb.tf
+++ b/aws/modules/register_group/elb.tf
@@ -5,6 +5,7 @@ resource "aws_elb" "load_balancer" {
   name = "${replace(format("%s--%s", replace(var.vpc_name,"discovery","disco"), var.id),"_","-")}"
   subnets = [ "${var.public_subnet_ids}" ]
   security_groups = ["${aws_security_group.load_balancer.id}"]
+  connection_draining = true
 
   listener = {
     instance_port = 80


### PR DESCRIPTION
I can't see any good reason why we don't enable this. Whilst we don't
add/remove instances from the ELB automatically, this will make world
rebuilds, machine reboots etc. have less of an impact.