### PR TITLE
Stop performing reverse DNS lookups of RDS clients

### DIFF
--- a/aws/modules/database/main.tf
+++ b/aws/modules/database/main.tf
@@ -16,7 +16,7 @@ resource "aws_db_instance" "db" {
   engine = "${var.engine}"
 
   db_subnet_group_name = "${aws_db_subnet_group.subnet_group.id}"
-  parameter_group_name = "${var.parameter_group_name}"
+  parameter_group_name = "${aws_db_parameter_group.db.id}"
 
   vpc_security_group_ids = ["${aws_security_group.db.id}"]
 

--- a/aws/modules/database/parameter_group.tf
+++ b/aws/modules/database/parameter_group.tf
@@ -1,0 +1,10 @@
+resource "aws_db_parameter_group" "db" {
+  name   = "${var.id}"
+  family = "postgres9.5"
+
+  parameter {
+    name = "log_hostname"
+    value = false
+    apply_method = "immediate"
+  }
+}

--- a/aws/modules/database/variables.tf
+++ b/aws/modules/database/variables.tf
@@ -30,10 +30,6 @@ variable "backup_retention_period" {
   default = "1"
 }
 
-variable "db_parameter_group_name" {
-  default = "postgresrdsgroup"
-}
-
 variable "engine" {
   default = "postgres"
 }
@@ -43,10 +39,6 @@ variable "instance_class" {
 }
 
 variable "maintenance_window" {}
-
-variable "parameter_group_name" {
-  default = "postgresrdsgroup"
-}
 
 variable "apply_immediately" {
   default = false

--- a/aws/registers/openregister.tf
+++ b/aws/registers/openregister.tf
@@ -21,7 +21,6 @@ module "openregister_db" {
   cidr_blocks = "${var.openregister_database_cidr_blocks}"
 
   instance_class = "${var.openregister_database_class_instance}"
-  parameter_group_name = "${lookup(var.rds_parameter_group_name, "openregister")}"
 
   username = "${var.read_api_rds_username}"
   password = "${var.openregister_database_master_password}"

--- a/aws/registers/variables.tf
+++ b/aws/registers/variables.tf
@@ -26,12 +26,6 @@ variable "public_cidr_blocks" { type = "list" }
 variable "admin_ips" { type = "list" }
 
 // RDS Configuration
-variable "rds_parameter_group_name" {
-  default = {
-    "openregister" = "postgresrdsgroup-9-5-2"
-  }
-}
-
 variable "rds_allocated_storage" {
   default = {
     "openregister" = 5


### PR DESCRIPTION
It turns out this was causing slowness for our RDS clients. This was
most pronounced when deploying but almost certainly affected most DB
connections in some way.

In a normal situation you would expect these reverse lookups to be fast.
However, because we accidentally chose "private" IP ranges within
`172.0.0.0/8` but outside of `172.16.0.0/12` we ended up assigning
privately IPs in the public address space. This means when Postgres
performs a reverse DNS lookup we rely on the owners of those IP address
to have configurations that respond with timely responses.

Frequently this is unproblematic. I imagine in some instances (although
I've not observed this personally) we'll see correct, affirmative
responses. In other case we've seen `NXDOMAIN` responses which should be
cached based off the `SOA` record. The slow ones I've personally
observed have responded with `SERVFAIL`; these are slow and are probably
not cached by recursors (§7.1 of RFC2308) so the failure has a bigger
impact.

Ultimately, we should look to fix the issue of misallocated private IP
ranges, but in the short-term this workaround should stop us from seeing
problems.