### PR TITLE
Support creating registers per deployment group (DO NOT MERGE) (yet)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ Then [plan and apply your terraform](#terraforming) code.
 - Duplicate an existing `register_group_*.tf` configuration and edit appropriately.
 - Specify the `group_instance_count` in `environments/<myenv>.tfvars`.
 
+Additionally, by creating a new register group, you will need to create a new 
+database and user, per environment. To do this:
+- Update application config files by running `ansible/upload_configs_to_s3.yml` playbook.
+- Create a new database using `ansible/create_databases.yml` playbook.
+- Generate credentials via the `ansible/generate_passwords.yml` playbook
+
 Then [plan and apply your terraform](#terraforming) code.
 
 ## How to create a new environment
@@ -192,7 +198,7 @@ create/update the config files from the registers:
 ### Create databases
 
 The `ansible/create_databases.yml` file creates the database, creates users and grants permissions 
-to users for any register in an environment that does not have the database set up.
+to users for any register group in an environment that does not have the database set up.
 
 	cd ansible
 	ansible-playbook create_databases.yml -e vpc=<myenv>

--- a/ansible/generate_passwords.yml
+++ b/ansible/generate_passwords.yml
@@ -29,4 +29,4 @@
       args:
         creates: "{{ pass_store_location | expanduser }}/{{ vpc }}/rds/openregister/{{ item }}.gpg"
       with_items:
-        - "{{ register_groups.keys() }}"
+        - "{{ register_groups.keys() | union(['master']) }}"

--- a/ansible/generate_passwords.yml
+++ b/ansible/generate_passwords.yml
@@ -28,5 +28,5 @@
       command: "pass generate --no-symbols {{ vpc }}/rds/openregister/{{ item }} {{ password_length }}"
       args:
         creates: "{{ pass_store_location | expanduser }}/{{ vpc }}/rds/openregister/{{ item }}.gpg"
-      with_flattened:
-        - "{{ register_groups.values() | union(['master']) }}"
+      with_items:
+        - "{{ register_groups.keys() }}"

--- a/ansible/roles/database/tasks/databases.yml
+++ b/ansible/roles/database/tasks/databases.yml
@@ -6,6 +6,6 @@
     login_host="{{ groups[inventory_group_name][0] }}"
     login_password="{{ master_password }}"
     login_user="{{ master_user }}"
-  with_flattened: "{{ register_groups.values() }}"
+  with_items: "{{ register_groups.keys() }}"
   register: create_db
   run_once: true

--- a/ansible/roles/database/tasks/user.yml
+++ b/ansible/roles/database/tasks/user.yml
@@ -10,7 +10,7 @@
     login_host="{{ groups[inventory_group_name][0] }}"
     login_user="{{ master_user }}"
     login_password="{{ master_password }}"
-  with_flattened: "{{ register_groups.values() }}"
+  with_items: "{{ register_groups.keys() }}"
   when: create_db
 
 - name: Set privileges for user
@@ -23,4 +23,4 @@
     login_host="{{ groups[inventory_group_name][0] }}"
     login_user="{{ item }}_openregister"
     login_password="{{ lookup('pass', '{{ vpc }}/rds/openregister/{{ item }}') }}"
-  with_flattened: "{{ register_groups.values() }}"
+  with_items: "{{ register_groups.keys() }}"

--- a/ansible/roles/openregister_config/templates/openregister-config.yaml.j2
+++ b/ansible/roles/openregister_config/templates/openregister-config.yaml.j2
@@ -26,12 +26,13 @@ database:
 {%- set app_user = "openregister" -%}
 {%- set app_password = lookup("pass", "{{ vpc }}/app/mint/" + reg).decode('utf-8') -%}
 {%- set settings = register_settings[reg] | default({}) -%}
-%- set default_field_register_url = "https://field." + vpc + ".openregister.org/records.yaml?page-size=5000"  -%}
+{%- set default_field_register_url = "https://field." + vpc + ".openregister.org/records.yaml?page-size=5000"  -%}
 {%- set default_register_register_url = "https://register." + vpc + ".openregister.org/records.yaml?page-size=5000"  -%}
 
 {%- if loop.first -%}
 trackingId: {{ tracking_id }}
 register: {{ register_name }}
+schema: {{ register_name }}
 {% if settings.custodian_name is defined %}custodianName: {{ settings.custodian_name }}{% endif %}
 enableDownloadResource: {{ settings.enable_download_resource | default(true) }}
 enableRegisterDataDelete: {{ settings.enable_register_data_delete | default(enable_register_data_delete) | default(false) }}
@@ -79,6 +80,7 @@ registers:
 {% else %}
   {{ reg }}:
     trackingId: {{ tracking_id }}
+    schema: {{ register_name }}
     {% if settings.custodian_name is defined %}custodianName: {{ settings.custodian_name }}{% endif %}
     enableDownloadResource: {{ settings.enable_download_resource | default(true) }}
     enableRegisterDataDelete: {{ settings.enable_register_data_delete | default(enable_register_data_delete) | default(false) }}

--- a/ansible/roles/openregister_config/templates/openregister-config.yaml.j2
+++ b/ansible/roles/openregister_config/templates/openregister-config.yaml.j2
@@ -1,21 +1,12 @@
 #jinja2: trim_blocks: False
 
-{% for reg in item.value -%}
-  {%- set rds_instance_name = vpc + "-openregister-db" -%}
-  {%- set password_store_key = vpc + "/rds/openregister/" + reg -%}
-  {%- set db_name = reg -%}
-  {%- set db_user = reg + "_openregister" -%}
-  {%- set db_password = lookup("pass", "{{ vpc }}/rds/openregister/" + reg).decode('utf-8') -%}
+{%- set rds_instance_name = vpc + "-openregister-db" -%}
+{%- set password_store_key = vpc + "/rds/openregister/" + item.key -%}
+{%- set db_name = item.key -%}
+{%- set db_user = item.key + "_openregister" -%}
+{%- set db_password = lookup("pass", "{{ vpc }}/rds/openregister/" + item.key).decode('utf-8') -%}
 
-  {%- set db_host = groups[rds_instance_name][0] -%}
-  {%- set register_name = reg -%}
-  {%- set app_user = "openregister" -%}
-  {%- set app_password = lookup("pass", "{{ vpc }}/app/mint/" + reg).decode('utf-8') -%}
-  {%- set settings = register_settings[reg] | default({}) -%}
-  {%- set default_field_register_url = "https://field." + vpc + ".openregister.org/records.yaml?page-size=5000"  -%}
-  {%- set default_register_register_url = "https://register." + vpc + ".openregister.org/records.yaml?page-size=5000"  -%}
-
-{%- if loop.first -%}
+{%- set db_host = groups[rds_instance_name][0] -%}
 database:
   driverClass: org.postgresql.Driver
   url: jdbc:postgresql://{{ db_host }}:{{ db_port | default(5432) }}/{{ db_name }}
@@ -30,6 +21,15 @@ database:
   properties:
     charSet: UTF-8
 
+{% for reg in item.value -%}
+{%- set register_name = reg -%}
+{%- set app_user = "openregister" -%}
+{%- set app_password = lookup("pass", "{{ vpc }}/app/mint/" + reg).decode('utf-8') -%}
+{%- set settings = register_settings[reg] | default({}) -%}
+%- set default_field_register_url = "https://field." + vpc + ".openregister.org/records.yaml?page-size=5000"  -%}
+{%- set default_register_register_url = "https://register." + vpc + ".openregister.org/records.yaml?page-size=5000"  -%}
+
+{%- if loop.first -%}
 trackingId: {{ tracking_id }}
 register: {{ register_name }}
 {% if settings.custodian_name is defined %}custodianName: {{ settings.custodian_name }}{% endif %}
@@ -78,20 +78,6 @@ registers:
 {% endif %}
 {% else %}
   {{ reg }}:
-    database:
-      driverClass: org.postgresql.Driver
-      url: jdbc:postgresql://{{ db_host }}:{{ db_port | default(5432) }}/{{ db_name }}
-      user: {{ db_user }}
-      password: {{ db_password }}
-
-      #db connection properties
-      initialSize: {{ db_initial_size | default(1) }}
-      minSize: {{ db_min_size | default(1) }}
-      maxSize: {{ db_max_size | default(4) }}
-
-      properties:
-        charSet: UTF-8
-
     trackingId: {{ tracking_id }}
     {% if settings.custodian_name is defined %}custodianName: {{ settings.custodian_name }}{% endif %}
     enableDownloadResource: {{ settings.enable_download_resource | default(true) }}


### PR DESCRIPTION
This PR introduces the concept of a database per *register group*, as opposed to per *register*. It does this by updating the `databases.yml` and `user.yml` files used in the process of creating a database, in addition to updating `generate_passwords.yml`, to all iterate over register groups.

The application configs generated through the playbook `upload_configs_to_s3.yml` are also updated, by amending the template file `openregister-config.yaml.j2` to only generate one database settings block for the specific register group that the config is being generated for.