### PR TITLE
Allow instances to add/removes themselves from ELBs

### DIFF
--- a/aws/modules/register_group/instance_policy.tf
+++ b/aws/modules/register_group/instance_policy.tf
@@ -66,10 +66,21 @@ resource "aws_iam_role_policy" "instance_policy" {
         {
             "Effect": "Allow",
             "Action": [
-                "ec2:DescribeTags"
+                "ec2:DescribeTags",
+                "elasticloadbalancing:Describe*"
             ],
             "Resource": [
                 "*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
+                "elasticloadbalancing:RegisterInstancesWithLoadBalancer"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:loadbalancer/${aws_elb.load_balancer.name}"
             ]
         }
     ]


### PR DESCRIPTION
This will allow us to push the responsibility of draining connections onto the ELB and therefore support zero-downtime deploys.