### PR TITLE
Explicitly specify the ELB connection draining timeout

### DIFF
--- a/aws/modules/register_group/elb.tf
+++ b/aws/modules/register_group/elb.tf
@@ -6,6 +6,7 @@ resource "aws_elb" "load_balancer" {
   subnets = [ "${var.public_subnet_ids}" ]
   security_groups = ["${aws_security_group.load_balancer.id}"]
   connection_draining = true
+  connection_draining_timeout = 300
 
   listener = {
     instance_port = 80


### PR DESCRIPTION
This value will become more important as we rely on ELBs to do
connection draining during deploys. We should be explicit about what the
value is rather than using the AWS default.