### PR TITLE
Use beta.openregister instead of register.gov.uk to get metadata

### DIFF
--- a/ansible/roles/openregister_config/templates/openregister-config.yaml.j2
+++ b/ansible/roles/openregister_config/templates/openregister-config.yaml.j2
@@ -12,8 +12,8 @@
   {%- set app_user = "openregister" -%}
   {%- set app_password = lookup("pass", "{{ vpc }}/app/mint/" + reg).decode('utf-8') -%}
   {%- set settings = register_settings[reg] | default({}) -%}
-  {%- set default_field_register_url = "https://field." + register_domain + "/records.yaml?page-size=5000"  -%}
-  {%- set default_register_register_url = "https://register." + register_domain + "/records.yaml?page-size=5000"  -%}
+  {%- set default_field_register_url = "https://field." + vpc + ".openregister.org/records.yaml?page-size=5000"  -%}
+  {%- set default_register_register_url = "https://register." + vpc + ".openregister.org/records.yaml?page-size=5000"  -%}
 
 {%- if loop.first -%}
 database:


### PR DESCRIPTION
When updating the register register and field register in beta, the previous results
are cahced for a while by the CDN. This causes problems when adding new registers to the
beta environment. It means that you have to invalidate the CDN for the field and register
registers in beta before deploying the new register. Otherwise the new register fails to
deploy because it cannot find metadata for the new register in the cached result obtained
from the metadata registers. This problem only occurs when creating registers in beta because
it is the only environment behind a CDN. This change means that we use the API behind the
CDN instead to get the metadata and solves the problem of needing to invalidate the cache.
This is a bit of a workaround but during the metadata epic we plan to remove this dependency on
running metadata registers and so it shouldn;t be around for long.