### PR TITLE
Fix Terraform deprecation warning

### DIFF
--- a/aws/modules/register_group/instance_policy.tf
+++ b/aws/modules/register_group/instance_policy.tf
@@ -92,5 +92,5 @@ resource "aws_iam_instance_profile" "instance_profile" {
   count = "${signum(var.instance_count)}"
   name = "${var.vpc_name}-${var.id}-profile"
   path = "/"
-  roles = [ "${aws_iam_role.instance_policy.name}" ]
+  role = "${aws_iam_role.instance_policy.name}"
 }


### PR DESCRIPTION
This resolves the following warnings:

```
There are warnings related to your configuration. If no errors occurred,
Terraform will continue despite these warnings. It is a good idea to resolve
these warnings in the near future.

Warnings:

  * module.address.aws_iam_instance_profile.instance_profile: "roles": [DEPRECATED] Use `role` instead. Only a single role can be passed to an IAM Instance Profile
  * module.basic.aws_iam_instance_profile.instance_profile: "roles": [DEPRECATED] Use `role` instead. Only a single role can be passed to an IAM Instance Profile
  * module.multi.aws_iam_instance_profile.instance_profile: "roles": [DEPRECATED] Use `role` instead. Only a single role can be passed to an IAM Instance Profile
```