### PR TITLE
Reduce the number of redundant/useless metrics sent to InfluxDB

### DIFF
--- a/aws/registers/templates/telegraf.conf
+++ b/aws/registers/templates/telegraf.conf
@@ -28,3 +28,15 @@
 [[inputs.udp_listener]]
   service_address = ":8092"
   data_format = "graphite"
+  namedrop = [
+    "*.mean_rate",
+    "*.m1_rate",
+    "*.m5_rate",
+    "*.m15_rate",
+    "*.p50",
+    "*.p75",
+    "*.p98",
+    "*.p999",
+    "*.percent-4xx-*",
+    "*.percent-5xx-*"
+  ]


### PR DESCRIPTION
Dropwizard provides a lot of metrics by default. Some of these are not
very valuable because they can be easily derived at query time (the mean
rates). Some of these seem excessive for our use case (it seems good
enough just to track p99 and p95).

We are only doing this so that we can keep the cost of InfluxCloud down.