### PR TITLE
Add indexes to config template and environment group_vars

### DIFF
--- a/ansible/group_vars/tag_Environment_beta
+++ b/ansible/group_vars/tag_Environment_beta
@@ -3,6 +3,8 @@ register_settings:
   country:
     custodian_name: Tony Worron
     history_page_url: https://registers.cloudapps.digital/registers/country
+    indexes:
+      - current-countries
     similar_registers:
       - territory
   datatype:
@@ -17,6 +19,8 @@ register_settings:
   local-authority-eng:
     custodian_name: Stephen McAllister
     history_page_url: https://registers.cloudapps.digital/registers/local-authority-eng
+    indexes:
+      - local-authority-by-type
   local-authority-type:
     custodian_name: Stephen McAllister
     history_page_url: https://registers.cloudapps.digital/registers/local-authority-type

--- a/ansible/group_vars/tag_Environment_test
+++ b/ansible/group_vars/tag_Environment_test
@@ -12,6 +12,8 @@ register_settings:
   country:
     similar_registers:
       - territory
+    indexes:
+      - current-countries
 
 register_groups:
   address:

--- a/ansible/roles/openregister_config/templates/openregister-config.yaml.j2
+++ b/ansible/roles/openregister_config/templates/openregister-config.yaml.j2
@@ -41,6 +41,11 @@ fieldsYamlLocation: {{ settings.fields_yaml_location | default(default_field_reg
 registersYamlLocation: {{ settings.registers_yaml_location | default(default_register_register_url) }}
 
 {% if settings.history_page_url is defined %}historyPageUrl: {{ settings.history_page_url }}{% endif %}
+{% if settings.indexes is defined %}indexes:
+  {% for index in settings.indexes -%}
+    - {{ index }}
+  {% endfor %}
+{% endif %}
 {% if settings.similar_registers is defined %}similarRegisters:
   {% for register in settings.similar_registers -%}
     - {{ register }}
@@ -85,6 +90,11 @@ registers:
     enableDownloadResource: {{ settings.enable_download_resource | default(true) }}
     enableRegisterDataDelete: {{ settings.enable_register_data_delete | default(enable_register_data_delete) | default(false) }}
     {% if settings.history_page_url is defined %}historyPageUrl: {{ settings.history_page_url }}{% endif %}
+    {% if settings.indexes is defined %}indexes:
+      {% for index in settings.indexes -%}
+        - {{ index }}
+      {% endfor %}
+    {% endif %}
     {% if settings.similar_registers is defined %}similarRegisters:
       {% for register in settings.similar_registers -%}
         - {{ register }}


### PR DESCRIPTION
This PR adds support for a new `indexes` property to register group configs via the J2 template. It then adds indexes for `current-countries` to the `country` register in `test` and `beta` environments and `local-authority-by-type` to the `local-authority-eng` register in `beta`.