### PR TITLE
Split Graphite buckets into InfluxDB fields and tags

### DIFF
--- a/aws/registers/templates/telegraf.conf
+++ b/aws/registers/templates/telegraf.conf
@@ -28,20 +28,42 @@
 [[inputs.udp_listener]]
   service_address = ":8092"
   data_format = "graphite"
+  fielddrop = [
+    "mean_rate",
+    "m5_rate",
+    "m15_rate",
+    "p50",
+    "p75",
+    "p98",
+    "p999",
+  ]
   namedrop = [
-    "*.mean_rate",
-    "*.m1_rate",
-    "*.m5_rate",
-    "*.m15_rate",
-    "*.p50",
-    "*.p75",
-    "*.p98",
-    "*.p999",
-    "*.percent-4xx-*",
-    "*.percent-5xx-*",
     "ch.qos.logback.core.Appender.debug.*",
     "ch.qos.logback.core.Appender.trace.*",
-    "jvm.*.usage"
+    "jvm.*.usage",
+  ]
+  templates = [
+    "ch.qos.logback.core.Appender.* measurement.measurement.measurement.measurement.measurement.level.field",
+    "io.dropwizard.db.ManagedPooledDataSource.* measurement.measurement.measurement.measurement.database.field",
+    "io.dropwizard.jetty.MutableServletContextHandler.* measurement.measurement.measurement.measurement.event.field",
+    "jvm.attribute.* measurement.measurement.field",
+    "jvm.buffers.* measurement.measurement.buffer.field",
+    "jvm.classloader.* measurement.measurement.field",
+    "jvm.filedescriptor measurement.field",
+    "jvm.gc.* measurement.measurement.event.field",
+    "jvm.memory.heap measurement.measurement.measurement.field",
+    "jvm.memory.non-heap measurement.measurement.measurement.field",
+    "jvm.memory.pools.* measurement.measurement.measurement.pool.field",
+    "jvm.memory.total measurement.measurement.measurement.field",
+    "jvm.threads measurement.measurement.field",
+    "org.apache.http.client.HttpClient.http-client.* measurement.measurement.measurement.measurement.measurement.measurement.method.field",
+    "org.apache.http.conn.HttpClientConnectionManager.http-client.* measurement.measurement.measurement.measurement.measurement.measurement.field",
+    "org.eclipse.jetty.server.HttpConnectionFactory.* measurement.measurement.measurement.measurement.measurement.port.measurement.field",
+    "org.eclipse.jetty.util.thread.QueuedThreadPool.* measurement.measurement.measurement.measurement.measurement.measurement.measurement.field",
+    "uk.gov.register.db.* measurement.measurement.measurement.measurement.dao.method.field",
+    "uk.gov.register.resources.* measurement.measurement.measurement.measurement.resource.method.field",
+    "uk.gov.register.views.* measurement.measurement.measurement.measurement.view.field",
   ]
   [inputs.udp_listener.tagdrop]
     environment = ["test"]
+    event = ["percent-4xx-*", "percent-5xx-*"]


### PR DESCRIPTION
Previously we had been storing each metric logged from Dropwizard as a
separate measurement in InfluxDB and generated multiple series tagged by
environment and (short-lived) hostnames. This lead to an explosion in
InfluxDB series cardinality.

We can use Telegraf to split the Graphite bucket into InfluxDB fields.
This helps reduce the number of series that InfluxDB has to store. For
example, a Graphite metric that stored aggregations such as `mean`,
`p99`, `p95` can be split into InfluxDB fields such that it will use
only one series rather than three.