### PR TITLE
Remove step from readme that is no longer required

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,10 +239,6 @@ Use the AWS API Gateway console to rotate the SSL certificate.
 Go to Custom Domain Names then select the custom domain name called `register.gov.uk` and use the Rotate button to
 add the new SSL certificate.
 
-## Create CloudFront distribution
-
-Create a CloudFront distribution for the new register. It should have an origin of `<myregister>.beta.openregister.org` and an alternate domain name of `<myregister>.register.gov.uk`.
-
 ## Create DNS record
 
 Use the AWS Route53 console to create a new DNS record for `<myregister>.register.gov.uk` and ensure the Alias Target matches


### PR DESCRIPTION
We now use terraform to automate this and isn't required
as a manual step.