### PR TITLE
Fix InfluxDB field extraction for views

### DIFF
--- a/aws/registers/templates/telegraf.conf
+++ b/aws/registers/templates/telegraf.conf
@@ -62,7 +62,7 @@
     "org.eclipse.jetty.util.thread.QueuedThreadPool.* measurement.measurement.measurement.measurement.measurement.measurement.measurement.field",
     "uk.gov.register.db.* measurement.measurement.measurement.measurement.dao.method.field",
     "uk.gov.register.resources.* measurement.measurement.measurement.measurement.resource.method.field",
-    "uk.gov.register.views.* measurement.measurement.measurement.measurement.view.field",
+    "uk.gov.register.views.* measurement.measurement.measurement.measurement.view.measurement.field",
   ]
   [inputs.udp_listener.tagdrop]
     event = ["percent-4xx-*", "percent-5xx-*"]


### PR DESCRIPTION
An example of a Graphite line from Dropwizard:

```
uk.gov.register.views.HomePageView.rendering.mean
```

The penultimate field appears to always be `rendering`.