### PR TITLE
Drop fields that are called `time`

### DIFF
--- a/aws/registers/templates/telegraf.conf
+++ b/aws/registers/templates/telegraf.conf
@@ -30,6 +30,7 @@
   service_address = ":8092"
   data_format = "graphite"
   fielddrop = [
+    "time",
     "mean_rate",
     "m5_rate",
     "m15_rate",


### PR DESCRIPTION
InfluxDB does not support fields with the name `time`[1]. If we send this
it can cause errors in InfluxDB. Ideally we should rename this field but
in the meantime we can just drop it.

[1] https://docs.influxdata.com/influxdb/v1.2/troubleshooting/frequently-asked-questions/#time