### PR TITLE
Tag metrics with region and availability zone

### DIFF
--- a/aws/registers/templates/telegraf.conf
+++ b/aws/registers/templates/telegraf.conf
@@ -1,6 +1,7 @@
 [global_tags]
   environment = "${environment}"
   tenancy-group = "$REGISTER_NAME"
+  datacenter = "$DATACENTER"
 
 [agent]
   interval = "5s"


### PR DESCRIPTION
This might be useful when diagnosing any future issues. It shouldn't
cost us anything extra series cardinality-wise because we're already
tagging with the host.

```
$ curl http://169.254.169.254/2016-09-02/meta-data/placement/availability-zone
eu-west-1a
```