### PR TITLE
Parse HTTP fields from log lines

### DIFF
--- a/aws/registers/templates/fluentd.conf
+++ b/aws/registers/templates/fluentd.conf
@@ -4,7 +4,43 @@
   bind 0.0.0.0
 </source>
 
-<match *.*>
+<filter docker.*>
+  @type parser
+  format json
+  key_name log
+  reserve_data true
+</filter>
+
+# Tag each event with the type of log that created it
+<match docker.*>
+  @type rewrite_tag_filter
+  rewriterule1 logger_name ^(.*)$ ${tag}.logger.$1
+</match>
+
+<filter docker.*.logger.http.request>
+  @type parser
+  format /^(?<octet_one>\d{1,3}).(?<octet_two>\d{1,3}).(?<octet_three>\d{1,3}).\d{1,3} (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")? (?<latency>[^ ]*)$/
+  time_format %d/%b/%Y:%H:%M:%S %z
+  reserve_data true
+  key_name message
+</filter>
+
+# Anonymize logs
+<filter docker.*.logger.http.request>
+  @type record_transformer
+  remove_keys octet_one,octet_two,octet_three
+  <record>
+    ip "${octet_one}.${octet_two}.${octet_three}.0"
+  </record>
+</filter>
+
+# Remove cruft
+<filter docker.*.logger.http.request>
+  @type record_transformer
+  remove_keys message
+</filter>
+
+<match docker.*.logger.**>
   type copy
 
   <store>

--- a/aws/registers/templates/fluentd.conf
+++ b/aws/registers/templates/fluentd.conf
@@ -19,7 +19,7 @@
 
 <filter docker.*.logger.http.request>
   @type parser
-  format /^(?<octet_one>\d{1,3}).(?<octet_two>\d{1,3}).(?<octet_three>\d{1,3}).\d{1,3} (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")? (?<latency>[^ ]*)$/
+  format /^(?<octet_one>\d{1,3}).(?<octet_two>\d{1,3}).(?<octet_three>\d{1,3}).\d{1,3} (?<cs_host>[^ ]*) (?<cs_user>[^ ]*) \[(?<time>[^\]]*)\] "(?<cs_method>\S+)(?: +(?<cs_uri_stem>[^\"]*) +\S*)?" (?<sc_status>[^ ]*) (?<cs_bytes>[^ ]*)(?: "(?<cs_referer>[^\"]*)" "(?<cs_user_agent>[^\"]*)")? (?<time_taken>[^ ]*)$/
   time_format %d/%b/%Y:%H:%M:%S %z
   reserve_data true
   key_name message
@@ -30,7 +30,7 @@
   @type record_transformer
   remove_keys octet_one,octet_two,octet_three
   <record>
-    ip "${octet_one}.${octet_two}.${octet_three}.0"
+    c_ip "${octet_one}.${octet_two}.${octet_three}.0"
   </record>
 </filter>
 


### PR DESCRIPTION
This removes entirely the need for any complex parsing/processing rules
in Sumologic. It also allows us to "anonymize" (by zero-ing the last
octet of an IPv4 address) requests.