### PR TITLE
Fix Terraform templating

### DIFF
--- a/aws/registers/templates/fluentd.conf
+++ b/aws/registers/templates/fluentd.conf
@@ -14,7 +14,7 @@
 # Tag each event with the type of log that created it
 <match docker.*>
   @type rewrite_tag_filter
-  rewriterule1 logger_name ^(.*)$ ${tag}.logger.$1
+  rewriterule1 logger_name ^(.*)$ $${tag}.logger.$1
 </match>
 
 <filter docker.*.logger.http.request>
@@ -30,7 +30,7 @@
   @type record_transformer
   remove_keys octet_one,octet_two,octet_three
   <record>
-    c_ip "${octet_one}.${octet_two}.${octet_three}.0"
+    c_ip "$${octet_one}.$${octet_two}.$${octet_three}.0"
   </record>
 </filter>
 


### PR DESCRIPTION
I forgot to run this through Terraform first. We need escape the fluentd
bits that look like `${name}` with `$${name}` so Terraform doesn't look for
passed in variables called `name`.