### PR TITLE
Temporarily limit Terraform's parallelism

### DIFF
--- a/aws/registers/Makefile
+++ b/aws/registers/Makefile
@@ -66,16 +66,16 @@ diff-config:
 	bash -c "diff --unified --report-identical-files environments/$(vpc).tfvars <(aws s3 cp s3://registers-terraform-config/$(vpc).tfvars -); exit 0"
 
 plan: configure-state
-	terraform plan $(defaults) -module-depth=$(module_depth)
+	terraform plan $(defaults) -module-depth=$(module_depth) -parallelism=1
 
 plan-destroy: configure-state
-	terraform plan -destroy $(defaults) -module-depth=$(module_depth)
+	terraform plan -destroy $(defaults) -module-depth=$(module_depth) -parallelism=1
 
 apply: configure-state
-	terraform apply $(defaults)
+	terraform apply $(defaults) -parallelism=1
 
 destroy: configure-state
-	terraform destroy $(defaults)
+	terraform destroy $(defaults) -parallelism=1
 
 config:
 	cd ../../ansible && ansible-playbook generate_passwords.yml \


### PR DESCRIPTION
Statuscake is fronted by Cloudflare and because there's some
rate-limiting there it means that we can easily trigger a rate-limiter
from that results in lot of 429 responses.

This change makes Terraform `plan` and `apply` slow, but reliable. I
tried larger numbers than `1` but these also triggered the rate-limiter.

We've been in contact with Statuscake and they're looking to try and up
the rate limit. However, it possibly also should be the case that the
Terraform provider should limit appropriately. This change should only
exist for as long as one of these things still haven't been resolved.