### PR TITLE
Log reponse from StatusCake

### DIFF
--- a/aws/lambda/python/statuscake-to-performance-platform/performance_platform.py
+++ b/aws/lambda/python/statuscake-to-performance-platform/performance_platform.py
@@ -22,6 +22,7 @@ def lambda_handler(event, context):
     tests_response.raise_for_status()
     results = tests_response.json()
 
+    print("StatusCake response: {}".format(results))
     uptimes = [result['Uptime'] for result in results if WEBSITE_MATCHER.match(result['WebsiteName'])]
     print("Uptimes: {}".format(uptimes))
     mean_uptime = mean(uptimes)/100.0


### PR DESCRIPTION
It appears as though there's some responses from StatusCake that result
in `None` being the value for `Uptime`. Adding some logging so we can
see what's happening.