### PR TITLE
Remove `address` in test

### DIFF
--- a/ansible/group_vars/tag_Environment_test
+++ b/ansible/group_vars/tag_Environment_test
@@ -7,8 +7,6 @@ register_settings:
     enable_register_data_delete: false
     fields_yaml_location: "s3://openregister.test.config/fields.yaml"
     registers_yaml_location: "s3://openregister.test.config/registers.yaml"
-  address:
-    enable_download_resource: false
   country:
     similar_registers:
       - territory
@@ -16,8 +14,6 @@ register_settings:
       - current-countries
 
 register_groups:
-  address:
-    - address
   basic:
     - register
     - field


### PR DESCRIPTION
It's a large register which we currently don't handle well. Migrations
are slow on this register and can cause deployments to appear to fail.
We can reassess whether it is sensible to have a register of this size
in test if/when we plan to create a register of this size.