### PR TITLE
Send uptime metrics as starting from the previous day

### DIFF
--- a/aws/lambda/python/statuscake-to-performance-platform/performance_platform.py
+++ b/aws/lambda/python/statuscake-to-performance-platform/performance_platform.py
@@ -2,7 +2,7 @@ import requests
 import json
 import re
 from statistics import mean
-from datetime import datetime
+from datetime import datetime, timedelta
 
 STATUSCAKE_API_KEY = "dummy_key"
 STATUSCAKE_API_USERNAME = "dummy_username"
@@ -28,8 +28,10 @@ def lambda_handler(event, context):
     mean_uptime = mean(uptimes)/100.0
     print("Mean uptime: {}".format(mean_uptime))
 
+    yesterday = datetime.utcnow() - timedelta(days=1)
+
     performance_platform_payload =  {
-        "_timestamp": datetime.utcnow().strftime("%Y-%m-%dT00:00:00+00:00"),
+        "_timestamp": yesterday.strftime("%Y-%m-%dT00:00:00+00:00"),
         "service": "govuk-registers",
         "check": "govuk-registers",
         "period": "day",

--- a/aws/lambda/python/statuscake-to-performance-platform/test/test_performance_platform.py
+++ b/aws/lambda/python/statuscake-to-performance-platform/test/test_performance_platform.py
@@ -7,7 +7,7 @@ from requests.exceptions import HTTPError
 import performance_platform
 
 EXPECTED_PAYLOAD = {
-    "_timestamp": "2017-05-08T00:00:00+00:00",
+    "_timestamp": "2017-05-07T00:00:00+00:00",
     "service": "govuk-registers",
     "check": "govuk-registers",
     "period": "day",


### PR DESCRIPTION
The Performance Platform expects the metric for a period to have a
timestamp for the start of that period. In this case the period is a day
and the uptime from StatusCake should be for the previous 24 hours.

We send our metrics at UTC midnight so the start of this period is
actually the previous day.