### PR TITLE
Change URL for local-authority-sct history page

### DIFF
--- a/ansible/group_vars/tag_Environment_beta
+++ b/ansible/group_vars/tag_Environment_beta
@@ -29,7 +29,7 @@ register_settings:
       - local-authority-by-type
   local-authority-sct:
     custodian_name: Hugh Buchanan
-    history_page_url: https://registers.cloudapps.digital/registers/local-authority-scotland
+    history_page_url: https://registers.cloudapps.digital/registers/local-authority-sct
   local-authority-type:
     custodian_name: Stephen McAllister
     history_page_url: https://registers.cloudapps.digital/registers/local-authority-type


### PR DESCRIPTION
Previously this was
https://registers.cloudapps.digital/registers/local-authority-scotland
but has been changed to
https://registers.cloudapps.digital/registers/local-authority-sct
so that the naming is consistent with the register.