### PR TITLE
Remove unneeded registers

### DIFF
--- a/ansible/group_vars/tag_Environment_alpha
+++ b/ansible/group_vars/tag_Environment_alpha
@@ -11,20 +11,9 @@ register_settings:
   field:
     custodian_name: Paul Downey
     enable_register_data_delete: false
-  government-organisation:
-    custodian_name: Neil Williams
-  government-service:
-    custodian_name: Thomas Moore
   industrial-classification:
     custodian_name: Charlie Roth-Smith
     history_page_url: https://registers.cloudapps.digital/registers/industrial-classification
-  local-authority-eng:
-    custodian_name: Stephen McAllister
-    history_page_url: https://registers.cloudapps.digital/registers/local-authority-eng
-  local-authority-sct:
-    custodian_name: Hugh Buchanan
-  local-authority-type:
-    custodian_name: Stephen McAllister
   notifiable-animal-disease:
     custodian_name: Jonathan Smith
     history_page_url: https://registers.cloudapps.digital/registers/notifiable-animal-disease
@@ -37,8 +26,6 @@ register_settings:
   occupation:
     custodian_name: Charlie Roth-Smith
     history_page_url: https://registers.cloudapps.digital/registers/occupation
-  prison-estate:
-    custodian_name: Richard Carling
   principal-local-authority:
     custodian_name: Lisa James
     history_page_url: https://registers.cloudapps.digital/registers/principal-local-authority
@@ -47,18 +34,12 @@ register_settings:
     enable_register_data_delete: false
     fields_yaml_location: "s3://openregister.alpha.config/fields.yaml"
     registers_yaml_location: "s3://openregister.alpha.config/registers.yaml"
-  registration-district:
-    custodian_name: Joanne Wilkes-Waterworth
   school-eng:
     custodian_name: Andrew Thomson
     history_page_url: https://registers.cloudapps.digital/registers/school-eng
   social-housing-provider:
     custodian_name: Julie Bond
     history_page_url: https://registers.cloudapps.digital/registers/social-housing-provider
-  territory:
-    custodian_name: Tony Worron
-    similar_registers:
-      - country
 
 register_groups:
   basic:
@@ -67,20 +48,12 @@ register_groups:
     - field
 
   multi:
-    - government-organisation
-    - government-service
     - industrial-classification
     - internal-drainage-board
-    - local-authority-eng
-    - local-authority-sct
-    - local-authority-type
     - notifiable-animal-disease
     - notifiable-animal-disease-confirmation-category
     - notifiable-animal-disease-investigation-category
     - occupation
     - principal-local-authority
-    - prison-estate
-    - registration-district
     - school-eng
     - social-housing-provider
-    - territory

--- a/ansible/group_vars/tag_Environment_discovery
+++ b/ansible/group_vars/tag_Environment_discovery
@@ -13,8 +13,6 @@ register_settings:
     registers_yaml_location: "s3://openregister.discovery.config/registers.yaml"
   address:
     enable_download_resource: false
-  registration-district:
-    custodian_name: Joanne Wilkes-Waterworth
   vehicle-colour:
     custodian_name: Rohan Gye
 
@@ -30,25 +28,13 @@ register_groups:
   multi:
     - clinical-commissioning-group
     - company
-    - food-authority
-    - food-premises
-    - food-premises-rating
-    - food-premises-type
     - government-domain
     - green-deal-certification-body
-    - industrial-classification
     - jobcentre
-    - local-authority-eng
     - local-authority-nir
-    - local-authority-sct
-    - local-authority-type
     - local-authority-wls
-    - occupation
     - place
-    - premises
     - prison
-    - registration-district
-    - social-housing-provider
     - statistical-geography
     - street
     - street-custodian


### PR DESCRIPTION
There are lots of duplicate registers across environments due to
promotion. Some of these can be removed. Now that we are not maintaining
the food-ratings demo we can also remove these registers.