### PR TITLE
Enable deletion of basic registers in alpha and discovery

### DIFF
--- a/ansible/group_vars/tag_Environment_alpha
+++ b/ansible/group_vars/tag_Environment_alpha
@@ -7,10 +7,8 @@ register_settings:
     enable_download_resource: false
   datatype:
     custodian_name: Paul Downey
-    enable_register_data_delete: false
   field:
     custodian_name: Paul Downey
-    enable_register_data_delete: false
   industrial-classification:
     custodian_name: Charlie Roth-Smith
     history_page_url: https://registers.cloudapps.digital/registers/industrial-classification
@@ -31,7 +29,6 @@ register_settings:
     history_page_url: https://registers.cloudapps.digital/registers/principal-local-authority
   register:
     custodian_name: Paul Downey
-    enable_register_data_delete: false
     fields_yaml_location: "s3://openregister.alpha.config/fields.yaml"
     registers_yaml_location: "s3://openregister.alpha.config/registers.yaml"
   school-eng:

--- a/ansible/group_vars/tag_Environment_discovery
+++ b/ansible/group_vars/tag_Environment_discovery
@@ -3,12 +3,7 @@ register_domain: discovery.openregister.org
 enable_register_data_delete: true
 
 register_settings:
-  datatype:
-    enable_register_data_delete: false
-  field:
-    enable_register_data_delete: false
   register:
-    enable_register_data_delete: false
     fields_yaml_location: "s3://openregister.discovery.config/fields.yaml"
     registers_yaml_location: "s3://openregister.discovery.config/registers.yaml"
   address:


### PR DESCRIPTION
This means it will be possible to delete the contents of the `register`,
`field` and `datatype` registers. These two environments/phases are not
expected to be consistent or satisfy the append-only rules of further
environments/phases. It is acceptable for these registers to be emptied
and reloaded as part of iterating on the shape of registers.