### PR TITLE
Revert "Enable deletion of basic registers in alpha and discovery"

### DIFF
--- a/ansible/group_vars/tag_Environment_alpha
+++ b/ansible/group_vars/tag_Environment_alpha
@@ -7,8 +7,10 @@ register_settings:
     enable_download_resource: false
   datatype:
     custodian_name: Paul Downey
+    enable_register_data_delete: false
   field:
     custodian_name: Paul Downey
+    enable_register_data_delete: false
   industrial-classification:
     custodian_name: Charlie Roth-Smith
     history_page_url: https://registers.cloudapps.digital/registers/industrial-classification
@@ -29,6 +31,7 @@ register_settings:
     history_page_url: https://registers.cloudapps.digital/registers/principal-local-authority
   register:
     custodian_name: Paul Downey
+    enable_register_data_delete: false
     fields_yaml_location: "s3://openregister.alpha.config/fields.yaml"
     registers_yaml_location: "s3://openregister.alpha.config/registers.yaml"
   school-eng:

--- a/ansible/group_vars/tag_Environment_discovery
+++ b/ansible/group_vars/tag_Environment_discovery
@@ -3,7 +3,12 @@ register_domain: discovery.openregister.org
 enable_register_data_delete: true
 
 register_settings:
+  datatype:
+    enable_register_data_delete: false
+  field:
+    enable_register_data_delete: false
   register:
+    enable_register_data_delete: false
     fields_yaml_location: "s3://openregister.discovery.config/fields.yaml"
     registers_yaml_location: "s3://openregister.discovery.config/registers.yaml"
   address:


### PR DESCRIPTION
This reverts commit 3f5f8943049ce806ebbbe25e42f2519e6a2cf2a6.

We have decided that to avoid accidentally emptying these registers and
causing a bunch of unplanned work that we'll stop deletion after we've
reloaded the registers.