### PR TITLE
Add school-type to and remove notifiable-animal-disease from alpha

### DIFF
--- a/ansible/group_vars/tag_Environment_alpha
+++ b/ansible/group_vars/tag_Environment_alpha
@@ -14,15 +14,6 @@ register_settings:
   industrial-classification:
     custodian_name: Charlie Roth-Smith
     history_page_url: https://registers.cloudapps.digital/registers/industrial-classification
-  notifiable-animal-disease:
-    custodian_name: Jonathan Smith
-    history_page_url: https://registers.cloudapps.digital/registers/notifiable-animal-disease
-  notifiable-animal-disease-confirmation-category:
-    custodian_name: Jonathan Smith
-    history_page_url: https://registers.cloudapps.digital/registers/notifiable-animal-disease-confirmation-category
-  notifiable-animal-disease-investigation-category:
-    custodian_name: Jonathan Smith
-    history_page_url: https://registers.cloudapps.digital/registers/notifiable-animal-disease-investigation-category
   occupation:
     custodian_name: Charlie Roth-Smith
     history_page_url: https://registers.cloudapps.digital/registers/occupation
@@ -37,6 +28,9 @@ register_settings:
   school-eng:
     custodian_name: Andrew Thomson
     history_page_url: https://registers.cloudapps.digital/registers/school-eng
+  school-type:
+    custodian_name: Andrew Thomson
+    history_page_url: https://registers.cloudapps.digital/registers/school-type
   social-housing-provider:
     custodian_name: Julie Bond
     history_page_url: https://registers.cloudapps.digital/registers/social-housing-provider
@@ -50,10 +44,8 @@ register_groups:
   multi:
     - industrial-classification
     - internal-drainage-board
-    - notifiable-animal-disease
-    - notifiable-animal-disease-confirmation-category
-    - notifiable-animal-disease-investigation-category
     - occupation
     - principal-local-authority
     - school-eng
+    - school-type
     - social-housing-provider

--- a/aws/registers/registers.tf
+++ b/aws/registers/registers.tf
@@ -398,54 +398,6 @@ module "local-authority-wls_register" {
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
-module "notifiable-animal-disease" {
-  source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "notifiable-animal-disease", false)}"
-
-  name = "notifiable-animal-disease"
-  environment = "${var.vpc_name}"
-  load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = "${module.core.dns_zone_id}"
-
-  enable_availability_checks = "${var.enable_availability_checks}"
-  cdn_configuration = "${var.cdn_configuration}"
-  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
-  pingdom_contact_ids = "${var.pingdom_contact_ids}"
-}
-
-module "notifiable-animal-disease-confirmation-category" {
-  source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "notifiable-animal-disease-confirmation-category", false)}"
-
-  name = "notifiable-animal-disease-confirmation-category"
-  environment = "${var.vpc_name}"
-  load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = "${module.core.dns_zone_id}"
-
-  enable_availability_checks = "${var.enable_availability_checks}"
-  cdn_configuration = "${var.cdn_configuration}"
-  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
-  pingdom_contact_ids = "${var.pingdom_contact_ids}"
-}
-
-module "notifiable-animal-disease-investigation-category" {
-  source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "notifiable-animal-disease-investigation-category", false)}"
-
-  name = "notifiable-animal-disease-investigation-category"
-  environment = "${var.vpc_name}"
-  load_balancer = "${module.multi.load_balancer}"
-  dns_zone_id = "${module.core.dns_zone_id}"
-
-  enable_availability_checks = "${var.enable_availability_checks}"
-  cdn_configuration = "${var.cdn_configuration}"
-  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
-  pingdom_contact_ids = "${var.pingdom_contact_ids}"
-}
-
 module "place_register" {
   source = "../modules/register"
   enabled = "${lookup(var.enabled_registers, "place", false)}"


### PR DESCRIPTION
Add the following register. This is to link school-types
from the existing school-eng register.

- school-type

Remove the following registers. This is because there are no
immediate plans to continue development of
notifiable-animal-disease registers.

- notifiable-animal-disease
- notifiable-animal-disease-investigation-category
- notifiable-animal-disease-confirmation-category