### PR TITLE
Write configs to somewhere more deployment agnostic

### DIFF
--- a/ansible/roles/openregister_config/templates/openregister-config.yaml.j2
+++ b/ansible/roles/openregister_config/templates/openregister-config.yaml.j2
@@ -53,7 +53,7 @@ registersYamlLocation: {{ settings.registers_yaml_location | default(default_reg
 {% endif %}
 
 registerDomain: {{ register_domain }}
-externalConfigDirectory: /srv/openregister-java
+externalConfigDirectory: /tmp
 downloadConfigs: true
 
 server:


### PR DESCRIPTION
Writing configs into `/srv/openregister-java` will only work in
situations where this directory exists and has been created by something
else. This is not the case when using PaaS. We can just write to `/tmp`
instead.