### PR TITLE
Fix canonicalization

### DIFF
--- a/scripts/rsfcreator.py
+++ b/scripts/rsfcreator.py
@@ -86,8 +86,10 @@ def generate_rsf(args):
             custodian_item_line, custodian_entry_line = rsf_for_line({'custodian': args.custodian}, 'custodian', 'system', key='custodian')
             print(custodian_item_line + '\n' + custodian_entry_line)
         for field in fields_by_name.values():
-            field_item_line, field_entry_line = rsf_for_line(field, 'field', 'system', key_prefix='field:')
+            field_tmp = remove_blanks(field)
+            field_item_line, field_entry_line = rsf_for_line(field_tmp, 'field', 'system', key_prefix='field:')
             print(field_item_line + '\n' + field_entry_line)
+        register_def_tmp = remove_blanks(register_def)
         reg_item_line, reg_entry_line = rsf_for_line(register_def, 'register', 'system', key_prefix='register:')
         print(reg_item_line + '\n' + reg_entry_line)
     # user data rsf

--- a/scripts/rsfcreator.py
+++ b/scripts/rsfcreator.py
@@ -55,7 +55,7 @@ def rsf_for_line(line_dict, key_field, entry_type, key_prefix='', key=None):
     if key is None:
         key = line_dict[key_field]
     timestamp = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
-    item_str = json.dumps(line_dict, separators=(',', ':'), sort_keys=True)
+    item_str = json.dumps(line_dict, ensure_ascii=False, separators=(',', ':'), sort_keys=True)
     item_hash = hashlib.sha256(item_str.encode("utf-8")).hexdigest()
     item_line = "add-item\t" + item_str
     entry_line = "append-entry\t{0}\t{1}{2}\t{3}\tsha-256:{4}".format(

--- a/scripts/rsfcreator_test.py
+++ b/scripts/rsfcreator_test.py
@@ -66,6 +66,12 @@ class TestRsfCreator(unittest.TestCase):
         with patch('sys.stdout', new=StringIO()) as fake_out:
             rsfcreator.generate_rsf(args)
 
+    def test_should_not_encode_special_characters_as_unicode(self):
+        line_map = {'notifiable-animal-disease':'WARBLE', 'name':'Wârble Fly', 'notifiable-locations':'Scôtland','notifiable-animal-disease-investigation-category':'WARBLE','notifiable-animal-disease-confirmation-category':'WARFLY'}
+        item_line, entry_line = rsfcreator.rsf_for_line( line_map, 'notifiable-animal-disease', 'user')
+        expected = 'add-item\t{"name":"Wârble Fly","notifiable-animal-disease":"WARBLE","notifiable-animal-disease-confirmation-category":"WARFLY","notifiable-animal-disease-investigation-category":"WARBLE","notifiable-locations":"Scôtland"}'
+        self.assertEqual(item_line, expected)
+
     def test_should_load_yaml_file(self):
         args = types.SimpleNamespace(register_name='field',
                 tsv=None, yaml='test-data/registry-data/data/alpha/field/notifiable-animal-disease.yaml',

--- a/scripts/test-data/expected/animal-diseases.rsf
+++ b/scripts/test-data/expected/animal-diseases.rsf
@@ -1,17 +1,17 @@
 add-item	{"name":"notifiable-animal-disease"}
-append-entry	system	name	2000-00-00T00:00:00Z	sha-256:72adf442443bb2c9c761e816057a2836a339e87ea045a20d187af4fe4fbb9c2b
+append-entry	system	name	2000-00-00T00:00:00Z	sha-256:cbf49606461ca636de1df58703a08a597e25088f82ab9b1765d5bf9d0a505485
 add-item	{"custodian":"Foo Bar"}
 append-entry	system	custodian	2000-00-00T00:00:00Z	sha-256:0bab730cbc358a00cdb7b29840408ce553014a1014e815bd42ceb0bac150bde2
 add-item	{"cardinality":"1","datatype":"string","field":"notifiable-animal-disease","phase":"alpha","register":"notifiable-animal-disease","text":"Notifiable animal disease code."}
 append-entry	system	field:notifiable-animal-disease	2000-00-00T00:00:00Z	sha-256:6c50807e6819d3835f15d02818486e80a439b1280c436e4eb7cc5de6b6cc7298
-add-item	{"cardinality":"1","datatype":"string","field":"name","phase":"alpha","register":"","text":"The commonly-used name of a record."}
-append-entry	system	field:name	2000-00-00T00:00:00Z	sha-256:d36c68bdb8c05983e14f2ae7d6b413eafe7ca2c02127e7bac15b5e51207ce7d7
-add-item	{"cardinality":"1","datatype":"datetime","field":"end-date","phase":"alpha","register":"","text":"The date a record stopped being applicable."}
-append-entry	system	field:end-date	2000-00-00T00:00:00Z	sha-256:ba872423f1f04e7bec73f16f12de3ef0d8e8baf45dcb38094e93fb9dde2adf4a
-add-item	{"cardinality":"n","datatype":"string","field":"notifiable-locations","phase":"alpha","register":"","text":"Locations where the disease is notifiable."}
-append-entry	system	field:notifiable-locations	2000-00-00T00:00:00Z	sha-256:c8d1e16aa32bcccf8e85a04801e554102a96e0daa17377f5dc820f0012c92f55
-add-item	{"cardinality":"1","datatype":"datetime","field":"start-date","phase":"alpha","register":"","text":"The date a record first became relevant to a register."}
-append-entry	system	field:start-date	2000-00-00T00:00:00Z	sha-256:74b9dc391d01fe62c49ac664e388c2ba28c8f60ca5297344939c7cc7160a8363
+add-item	{"cardinality":"1","datatype":"string","field":"name","phase":"alpha","text":"The commonly-used name of a record."}
+append-entry	system	field:name	2000-00-00T00:00:00Z	sha-256:9eec41f22ae07d3ff5c99bf9a72173e2368833803069aaabacd821f0a497138d
+add-item	{"cardinality":"1","datatype":"datetime","field":"end-date","phase":"alpha","text":"The date a record stopped being applicable."}
+append-entry	system	field:end-date	2000-00-00T00:00:00Z	sha-256:237c519865320df6edf9961db4135a7cf67a31aba0741ebdba7a45d32a31e2ed
+add-item	{"cardinality":"n","datatype":"string","field":"notifiable-locations","phase":"alpha","text":"Locations where the disease is notifiable."}
+append-entry	system	field:notifiable-locations	2000-00-00T00:00:00Z	sha-256:9521ab81c0c4e54297d8bea15265bddc67aa24d124e9809519a088f3abd3547f
+add-item	{"cardinality":"1","datatype":"datetime","field":"start-date","phase":"alpha","text":"The date a record first became relevant to a register."}
+append-entry	system	field:start-date	2000-00-00T00:00:00Z	sha-256:f31392366a61837257274bcd038ec73ecc87f56673686f559a283f834745d8bb
 add-item	{"cardinality":"1","datatype":"string","field":"notifiable-animal-disease-investigation-category","phase":"alpha","register":"notifiable-animal-disease-investigation-category","text":"Veterinary Exotic Notifiable Disease Unit investigation category."}
 append-entry	system	field:notifiable-animal-disease-investigation-category	2000-00-00T00:00:00Z	sha-256:21a324aabfdb6e712cfebd1823963d2d2d93087f37c55c4c492ded3110c594f9
 add-item	{"cardinality":"1","datatype":"string","field":"notifiable-animal-disease-confirmation-category","phase":"alpha","register":"notifiable-animal-disease-confirmation-category","text":"Contingency planning confirmation category."}

--- a/scripts/test-data/expected/field-register.rsf
+++ b/scripts/test-data/expected/field-register.rsf
@@ -3,12 +3,12 @@ add-item	{"cardinality":"1","datatype":"string","field":"field","phase":"alpha",
 append-entry	system	field:field	2000-00-00T00:00:00Z	sha-256:1416754313960422972411315398ca0c8a9875153e5489acd5fbef18c5ef7e2a
 add-item	{"cardinality":"1","datatype":"string","field":"register","phase":"alpha","register":"register","text":"The name of a register."}
 append-entry	system	field:register	2000-00-00T00:00:00Z	sha-256:20413e154fc235d323775983f355b33b0e42032d6c7cac98b8681b44110f53b3
-add-item	{"cardinality":"1","datatype":"string","field":"cardinality","phase":"alpha","register":"","text":"A character (either 1 or n) that explains if a field in a register can contain multiple values."}
-append-entry	system	field:cardinality	2000-00-00T00:00:00Z	sha-256:ca8188c7c1ca51fd5cdcdf17b6e7c16129f7eafcfda1ed3a6fa69dca028aec38
-add-item	{"cardinality":"1","datatype":"text","field":"text","phase":"alpha","register":"","text":"Any additional information about a record in a register."}
-append-entry	system	field:text	2000-00-00T00:00:00Z	sha-256:64130ef564805d87ef8b96408c7074535644709812a9e0dd5067267d54cf4e42
-add-item	{"cardinality":"1","datatype":"string","field":"phase","phase":"alpha","register":"","text":"The stage of development a register is in. There are 4 phases - discovery, alpha, beta and live."}
-append-entry	system	field:phase	2000-00-00T00:00:00Z	sha-256:0acd04e6758fd52761d15f2f308b598c8dd57e33b42652ae9652b0f227afb501
+add-item	{"cardinality":"1","datatype":"string","field":"cardinality","phase":"alpha","text":"A character (either 1 or n) that explains if a field in a register can contain multiple values."}
+append-entry	system	field:cardinality	2000-00-00T00:00:00Z	sha-256:b06cdf308960aea9d4ebce2c7895ff7a70fe253a74a8a87c94387025fcddae1a
+add-item	{"cardinality":"1","datatype":"text","field":"text","phase":"alpha","text":"Any additional information about a record in a register."}
+append-entry	system	field:text	2000-00-00T00:00:00Z	sha-256:2108df725a601f3354242aa1e4e6dfb256a30b5642e367239b176223668fdad6
+add-item	{"cardinality":"1","datatype":"string","field":"phase","phase":"alpha","text":"The stage of development a register is in. There are 4 phases - discovery, alpha, beta and live."}
+append-entry	system	field:phase	2000-00-00T00:00:00Z	sha-256:6b4f1465970264c09e5572824c94301e5c76a310be4dc41e04bd301c9cd723d2
 add-item	{"fields":["field","datatype","phase","register","cardinality","text"],"phase":"alpha","register":"field","registry":"cabinet-office","text":"Field names which may appear in a register"}
 append-entry	system	register:field	2000-00-00T00:00:00Z	sha-256:e744c984158aea29904201aee263815a4bdab401ff8e6a194b25ff640ce191e2
 add-item	{"cardinality":"n","datatype":"string","field":"notifiable-locations","phase":"alpha","text":"Locations where the disease is notifiable."}

--- a/scripts/test-data/expected/register-register.rsf
+++ b/scripts/test-data/expected/register-register.rsf
@@ -1,13 +1,13 @@
 add-item	{"cardinality":"1","datatype":"string","field":"register","phase":"alpha","register":"register","text":"The name of a register."}
 append-entry	system	field:register	2000-00-00T00:00:00Z	sha-256:20413e154fc235d323775983f355b33b0e42032d6c7cac98b8681b44110f53b3
-add-item	{"cardinality":"1","datatype":"string","field":"phase","phase":"alpha","register":"","text":"The stage of development a register is in. There are 4 phases - discovery, alpha, beta and live."}
-append-entry	system	field:phase	2000-00-00T00:00:00Z	sha-256:0acd04e6758fd52761d15f2f308b598c8dd57e33b42652ae9652b0f227afb501
-add-item	{"cardinality":"1","datatype":"string","field":"registry","phase":"alpha","register":"","text":"The organisation responsible for the data in a register. The custodian is usually from the registry."}
-append-entry	system	field:registry	2000-00-00T00:00:00Z	sha-256:4177c67af31f2309c6aef4de9ac0362bf73f07a8ba2c9796f1a113a2d6171a86
-add-item	{"cardinality":"1","datatype":"text","field":"copyright","phase":"alpha","register":"","text":"The copyright and licensing terms which may apply to the data held in a register."}
-append-entry	system	field:copyright	2000-00-00T00:00:00Z	sha-256:c889a4904c4fd4dc3d405cf892a73d874d8aa2949918c8495e2d96a62f1b13c4
-add-item	{"cardinality":"1","datatype":"text","field":"text","phase":"alpha","register":"","text":"Any additional information about a record in a register."}
-append-entry	system	field:text	2000-00-00T00:00:00Z	sha-256:64130ef564805d87ef8b96408c7074535644709812a9e0dd5067267d54cf4e42
+add-item	{"cardinality":"1","datatype":"string","field":"phase","phase":"alpha","text":"The stage of development a register is in. There are 4 phases - discovery, alpha, beta and live."}
+append-entry	system	field:phase	2000-00-00T00:00:00Z	sha-256:6b4f1465970264c09e5572824c94301e5c76a310be4dc41e04bd301c9cd723d2
+add-item	{"cardinality":"1","datatype":"string","field":"registry","phase":"alpha","text":"The organisation responsible for the data in a register. The custodian is usually from the registry."}
+append-entry	system	field:registry	2000-00-00T00:00:00Z	sha-256:b58faf5ccd130997fc215f8a47bafdbbd2654490df3932b8189c61fd1108fa97
+add-item	{"cardinality":"1","datatype":"text","field":"copyright","phase":"alpha","text":"The copyright and licensing terms which may apply to the data held in a register."}
+append-entry	system	field:copyright	2000-00-00T00:00:00Z	sha-256:4a4cd52643043366688f3cff0144d39371ca93c485361b934ccdd60faf4217cf
+add-item	{"cardinality":"1","datatype":"text","field":"text","phase":"alpha","text":"Any additional information about a record in a register."}
+append-entry	system	field:text	2000-00-00T00:00:00Z	sha-256:2108df725a601f3354242aa1e4e6dfb256a30b5642e367239b176223668fdad6
 add-item	{"cardinality":"n","datatype":"string","field":"fields","phase":"alpha","register":"field","text":"The names of the fields in a register."}
 append-entry	system	field:fields	2000-00-00T00:00:00Z	sha-256:7f8b3fe1eff4540654395e3097d321a240b0931f9a28b4bae7c3099d3efb0370
 add-item	{"fields":["register","text","registry","phase","copyright","fields"],"phase":"alpha","register":"register","registry":"cabinet-office","text":"Registers maintained by the UK government"}

--- a/scripts/test-data/special-characters.tsv
+++ b/scripts/test-data/special-characters.tsv
@@ -1,0 +1,3 @@
+notifiable-animal-disease	name	notifiable-locations	notifiable-animal-disease-investigation-category	notifiable-animal-disease-confirmation-category	start-date	end-date
+AHS	African horse sickness	England;Scotland;Wales	IDHR	AHS		
+WARBLE	Wârble Fly	Scôtland	WARBLE	WARFLY		


### PR DESCRIPTION
This PR fixes canonicalization with the `rsfcreator.py` script so that empty key-value pairs are not included in metadata items and to stop escaping special characters as unicode.