### PR TITLE
Removal of redundant code

### DIFF
--- a/ansible/group_vars/tag_Environment_alpha
+++ b/ansible/group_vars/tag_Environment_alpha
@@ -3,8 +3,6 @@ register_domain: alpha.openregister.org
 enable_register_data_delete: true
 
 register_settings:
-  address:
-    enable_download_resource: false
   datatype:
     custodian_name: Paul Downey
     enable_register_data_delete: false


### PR DESCRIPTION
We do not have an address register in alpha therefore this code
does not need to exist.