### PR TITLE
Do not send metrics on PaaS

### DIFF
--- a/ansible/roles/openregister_config/tasks/main.yml
+++ b/ansible/roles/openregister_config/tasks/main.yml
@@ -16,7 +16,17 @@
   with_dict: "{{ register_groups }}"
 
 - name: Generate openregister-java configuration files
+  vars:
+    paas: false
   template:
     src="templates/openregister-config.yaml.j2"
     dest="{{ workdir }}/{{ vpc }}/{{ item.key }}/openregister/config.yaml"
+  with_dict: "{{ register_groups }}"
+
+- name: Generate openregister-java configuration files (PaaS)
+  vars:
+    paas: true
+  template:
+    src="templates/openregister-config.yaml.j2"
+    dest="{{ workdir }}/{{ vpc }}/{{ item.key }}/openregister/paas-config.yaml"
   with_dict: "{{ register_groups }}"

--- a/ansible/roles/openregister_config/templates/openregister-config.yaml.j2
+++ b/ansible/roles/openregister_config/templates/openregister-config.yaml.j2
@@ -72,6 +72,7 @@ logging:
   appenders:
     - type: logstash-console
 
+{% if not paas %}
 metrics:
   reporters:
     - type: graphite
@@ -79,6 +80,7 @@ metrics:
       port: 8092
       transport: udp
       frequency: 5 seconds
+{% endif %}
 
 {% if loop.length > 1 %}
 registers:

--- a/ansible/roles/openregister_config/templates/openregister-config.yaml.j2
+++ b/ansible/roles/openregister_config/templates/openregister-config.yaml.j2
@@ -9,9 +9,13 @@
 {%- set db_host = groups[rds_instance_name][0] -%}
 database:
   driverClass: org.postgresql.Driver
+  {% if not paas %}
   url: jdbc:postgresql://{{ db_host }}:{{ db_port | default(5432) }}/{{ db_name }}
   user: {{ db_user }}
   password: {{ db_password }}
+  {% else %}
+  url: "substituted-at-runtime-from-environment"
+  {% endif %}
 
   #db connection properties
   initialSize: {{ db_initial_size | default(1) }}


### PR DESCRIPTION
As it currently stands we don't have a good story for how to deal with
metrics from our application whilst running on PaaS. We can remove the
`metrics` block from our configuration so that our app doesn't
continuously throw exceptions and figure out a longer term plan later.