### PR TITLE
Be explicit about which port to listen on

### DIFF
--- a/ansible/roles/openregister_config/templates/openregister-config.yaml.j2
+++ b/ansible/roles/openregister_config/templates/openregister-config.yaml.j2
@@ -57,6 +57,9 @@ externalConfigDirectory: /tmp
 downloadConfigs: true
 
 server:
+ connector:
+    type: http
+    port: {% if paas %}${PORT}{% else %}8080{% endif %}
   registerDefaultExceptionMappers: false
   requestLog:
     appenders:


### PR DESCRIPTION
NB: This won't work until #404 is merged first.

We accidentally listen on the same port that PaaS seems to use by
default. There's no good reason why we should; there's an environment
variable provided by PaaS for this purpose.