### PR TITLE
Use correct logstash appender for PaaS/AWS

### DIFF
--- a/ansible/roles/openregister_config/templates/openregister-config.yaml.j2
+++ b/ansible/roles/openregister_config/templates/openregister-config.yaml.j2
@@ -66,8 +66,14 @@ server:
       port: {% if paas %}${PORT}{% else %}8080{% endif %}
   registerDefaultExceptionMappers: false
   requestLog:
+    {% if paas %}
     appenders:
       - type: access-logstash-console
+    {% else %}
+    type: classic
+    appenders:
+      - type: logstash-console
+    {% endif %}
 
 credentials:
   user: {{ app_user }}


### PR DESCRIPTION
The access-logstash-console appender does some useful parseing
of fields. However, this is incompatible with fluentd, which
consumes logs when running the application on AWS. We therefore
need to make sure we use the correct appender for the platform
on which we are running the application.