### PR TITLE
Add PaaS deployment side-by-side with AWS deployment

### DIFF
--- a/aws/modules/paas_codebuild_deploy/main.tf
+++ b/aws/modules/paas_codebuild_deploy/main.tf
@@ -1,0 +1,43 @@
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" { current = true }
+
+resource "aws_codebuild_project" "deploy_to_paas" {
+  name = "${var.environment}-${var.register_group}-deploy"
+  description = "Deploy the \"${var.register_group}\" register group to the \"${var.environment}\" environment on PaaS"
+  build_timeout = "30"
+  service_role = "${var.codebuild_role_arn}"
+
+  artifacts {
+    type = "CODEPIPELINE"
+  }
+
+  environment {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image        = "aws/codebuild/ubuntu-base:14.04"
+    type         = "LINUX_CONTAINER"
+
+    environment_variable {
+      "name"  = "CF_ORGANIZATION"
+      "value" = "${var.cloudfoundry_organization}"
+    }
+
+    environment_variable {
+      "name"  = "CF_SPACE"
+      "value" = "${var.cloudfoundry_space}"
+    }
+
+    environment_variable {
+      "name"  = "ENVIRONMENT"
+      "value" = "${var.environment}"
+    }
+
+    environment_variable {
+      "name"  = "REGISTER_GROUP"
+      "value" = "${var.register_group}"
+    }
+  }
+
+  source {
+    type = "CODEPIPELINE"
+  }
+}

--- a/aws/modules/paas_codebuild_deploy/outputs.tf
+++ b/aws/modules/paas_codebuild_deploy/outputs.tf
@@ -1,0 +1,3 @@
+output "name" {
+  value = "${aws_codebuild_project.deploy_to_paas.name}"
+}

--- a/aws/modules/paas_codebuild_deploy/variables.tf
+++ b/aws/modules/paas_codebuild_deploy/variables.tf
@@ -1,0 +1,5 @@
+variable "cloudfoundry_space" {}
+variable "cloudfoundry_organization" {}
+variable "environment" {}
+variable "register_group" {}
+variable "codebuild_role_arn" {}

--- a/aws/pipeline/iam.tf
+++ b/aws/pipeline/iam.tf
@@ -1,0 +1,120 @@
+resource "aws_iam_role" "codebuild_role" {
+  name = "codebuild-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "codebuild.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role" "codepipeline" {
+  name = "codepipeline"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": "sts:AssumeRole",
+    "Principal": {
+      "Service": "codepipeline.amazonaws.com"
+    }
+  }]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "codepipeline" {
+  name = "codepipeline"
+  role = "${aws_iam_role.codepipeline.id}"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Resource": "arn:aws:s3:::codepipeline*",
+    "Effect": "Allow",
+    "Action": "s3:PutObject"
+  }, {
+    "Resource": "*",
+    "Effect": "Allow",
+    "Action": [
+      "codebuild:BatchGetBuilds",
+      "codebuild:StartBuild",
+      "codedeploy:CreateDeployment",
+      "codedeploy:GetApplicationRevision",
+      "codedeploy:GetDeployment",
+      "codedeploy:GetDeploymentConfig",
+      "codedeploy:RegisterApplicationRevision",
+      "iam:PassRole",
+      "lambda:InvokeFunction",
+      "lambda:ListFunctions",
+      "s3:GetObject",
+      "s3:GetObjectVersion",
+      "s3:GetBucketVersioning"
+    ]
+  }]
+}
+EOF
+}
+
+resource "aws_iam_policy" "codebuild_policy" {
+  name        = "codebuild-policy"
+  path        = "/service-role/"
+  description = "Policy used in trust relationship with CodeBuild"
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ],
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/paas-deploy-user",
+        "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/paas-deploy-password",
+        "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/paas-deploy-aws-key",
+        "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/paas-deploy-aws-secret"
+      ],
+      "Action": [
+        "ssm:GetParameters"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key/${data.aws_kms_alias.paas_deploy.target_key_id}"
+      ],
+      "Action": [
+        "kms:Decrypt"
+      ]
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_policy_attachment" "codebuild_policy_attachment" {
+  name = "codebuild-policy-attachment"
+  policy_arn = "${aws_iam_policy.codebuild_policy.arn}"
+  roles = ["${aws_iam_role.codebuild_role.id}"]
+}

--- a/aws/pipeline/main.tf
+++ b/aws/pipeline/main.tf
@@ -14,3 +14,4 @@ provider "aws" {
 
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" { current = true }
+data "aws_kms_alias" "paas_deploy" { name = "alias/paas-deploy" }

--- a/aws/pipeline/openregister-java_pipeline.tf
+++ b/aws/pipeline/openregister-java_pipeline.tf
@@ -1,51 +1,73 @@
-resource "aws_iam_role" "codepipeline" {
-  name = "codepipeline"
-
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [{
-    "Effect": "Allow",
-    "Action": "sts:AssumeRole",
-    "Principal": {
-      "Service": "codepipeline.amazonaws.com"
-    }
-  }]
-}
-EOF
+module "test_basic" {
+  source = "../modules/paas_codebuild_deploy"
+  cloudfoundry_space = "test"
+  cloudfoundry_organization = "openregister"
+  environment = "test"
+  register_group = "basic"
+  codebuild_role_arn = "${aws_iam_role.codebuild_role.arn}"
 }
 
-resource "aws_iam_role_policy" "codepipeline" {
-  name = "codepipeline"
-  role = "${aws_iam_role.codepipeline.id}"
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [{
-    "Resource": "arn:aws:s3:::codepipeline*",
-    "Effect": "Allow",
-    "Action": "s3:PutObject"
-  }, {
-    "Resource": "*",
-    "Effect": "Allow",
-    "Action": [
-      "codebuild:BatchGetBuilds",
-      "codebuild:StartBuild",
-      "codedeploy:CreateDeployment",
-      "codedeploy:GetApplicationRevision",
-      "codedeploy:GetDeployment",
-      "codedeploy:GetDeploymentConfig",
-      "codedeploy:RegisterApplicationRevision",
-      "iam:PassRole",
-      "lambda:InvokeFunction",
-      "lambda:ListFunctions",
-      "s3:GetObject",
-      "s3:GetObjectVersion",
-      "s3:GetBucketVersioning"
-    ]
-  }]
+module "test_multi" {
+  source = "../modules/paas_codebuild_deploy"
+  cloudfoundry_space = "test"
+  cloudfoundry_organization = "openregister"
+  environment = "test"
+  register_group = "multi"
+  codebuild_role_arn = "${aws_iam_role.codebuild_role.arn}"
 }
-EOF
+
+module "discovery_basic" {
+  source = "../modules/paas_codebuild_deploy"
+  cloudfoundry_space = "prod"
+  cloudfoundry_organization = "openregister"
+  environment = "discovery"
+  register_group = "basic"
+  codebuild_role_arn = "${aws_iam_role.codebuild_role.arn}"
+}
+
+module "discovery_multi" {
+  source = "../modules/paas_codebuild_deploy"
+  cloudfoundry_space = "prod"
+  cloudfoundry_organization = "openregister"
+  environment = "discovery"
+  register_group = "multi"
+  codebuild_role_arn = "${aws_iam_role.codebuild_role.arn}"
+}
+
+module "alpha_basic" {
+  source = "../modules/paas_codebuild_deploy"
+  cloudfoundry_space = "prod"
+  cloudfoundry_organization = "openregister"
+  environment = "alpha"
+  register_group = "basic"
+  codebuild_role_arn = "${aws_iam_role.codebuild_role.arn}"
+}
+
+module "alpha_multi" {
+  source = "../modules/paas_codebuild_deploy"
+  cloudfoundry_space = "prod"
+  cloudfoundry_organization = "openregister"
+  environment = "alpha"
+  register_group = "multi"
+  codebuild_role_arn = "${aws_iam_role.codebuild_role.arn}"
+}
+
+module "beta_basic" {
+  source = "../modules/paas_codebuild_deploy"
+  cloudfoundry_space = "prod"
+  cloudfoundry_organization = "openregister"
+  environment = "beta"
+  register_group = "basic"
+  codebuild_role_arn = "${aws_iam_role.codebuild_role.arn}"
+}
+
+module "beta_multi" {
+  source = "../modules/paas_codebuild_deploy"
+  cloudfoundry_space = "prod"
+  cloudfoundry_organization = "openregister"
+  environment = "beta"
+  register_group = "multi"
+  codebuild_role_arn = "${aws_iam_role.codebuild_role.arn}"
 }
 
 resource "aws_codepipeline" "pipeline" {
@@ -89,6 +111,32 @@ resource "aws_codepipeline" "pipeline" {
       configuration {
         ApplicationName = "openregister-app"
         DeploymentGroupName = "test"
+      }
+    }
+
+    action {
+      name = "deploy-test-basic"
+      category = "Build"
+      owner = "AWS"
+      provider = "CodeBuild"
+      input_artifacts = ["openregister_package"]
+      version = "1"
+
+      configuration {
+        ProjectName = "${module.test_basic.name}"
+      }
+    }
+
+    action {
+      name = "deploy-test-multi"
+      category = "Build"
+      owner = "AWS"
+      provider = "CodeBuild"
+      input_artifacts = ["openregister_package"]
+      version = "1"
+
+      configuration {
+        ProjectName = "${module.test_multi.name}"
       }
     }
   }
@@ -135,6 +183,58 @@ resource "aws_codepipeline" "pipeline" {
         DeploymentGroupName = "alpha"
       }
     }
+
+    action {
+      name = "deploy-discovery-basic"
+      category = "Build"
+      owner = "AWS"
+      provider = "CodeBuild"
+      input_artifacts = ["openregister_package"]
+      version = "1"
+
+      configuration {
+        ProjectName = "${module.discovery_basic.name}"
+      }
+    }
+
+    action {
+      name = "deploy-discovery-multi"
+      category = "Build"
+      owner = "AWS"
+      provider = "CodeBuild"
+      input_artifacts = ["openregister_package"]
+      version = "1"
+
+      configuration {
+        ProjectName = "${module.discovery_multi.name}"
+      }
+    }
+
+    action {
+      name = "deploy-alpha-basic"
+      category = "Build"
+      owner = "AWS"
+      provider = "CodeBuild"
+      input_artifacts = ["openregister_package"]
+      version = "1"
+
+      configuration {
+        ProjectName = "${module.alpha_basic.name}"
+      }
+    }
+
+    action {
+      name = "deploy-alpha-multi"
+      category = "Build"
+      owner = "AWS"
+      provider = "CodeBuild"
+      input_artifacts = ["openregister_package"]
+      version = "1"
+
+      configuration {
+        ProjectName = "${module.alpha_multi.name}"
+      }
+    }
   }
 
   stage {
@@ -163,6 +263,32 @@ resource "aws_codepipeline" "pipeline" {
       configuration {
         ApplicationName = "openregister-app"
         DeploymentGroupName = "beta"
+      }
+    }
+
+    action {
+      name = "deploy-beta-basic"
+      category = "Build"
+      owner = "AWS"
+      provider = "CodeBuild"
+      input_artifacts = ["openregister_package"]
+      version = "1"
+
+      configuration {
+        ProjectName = "${module.beta_basic.name}"
+      }
+    }
+
+    action {
+      name = "deploy-beta-multi"
+      category = "Build"
+      owner = "AWS"
+      provider = "CodeBuild"
+      input_artifacts = ["openregister_package"]
+      version = "1"
+
+      configuration {
+        ProjectName = "${module.beta_multi.name}"
       }
     }
   }


### PR DESCRIPTION
Whilst migrating to the new PaaS deployments we should run the old
side-by-side with the new. When we've made the switch we can then remove
the old AWS deployments.