### PR TITLE
Swap DNS to PaaS-backed infrastructure

### DIFF
--- a/aws/modules/register/dns.tf
+++ b/aws/modules/register/dns.tf
@@ -6,8 +6,8 @@ resource "aws_route53_record" "record" {
   zone_id = "${var.dns_zone_id}"
 
   alias {
-    name = "${var.load_balancer["dns_name"]}"
-    zone_id = "${var.load_balancer["zone_id"]}"
+    name = "${var.paas_cdn_domain_name}"
+    zone_id = "${var.paas_cdn_hosted_zone_id}"
     evaluate_target_health = false // we don't have anything to fail over to at the moment
   }
 }

--- a/aws/modules/register/variables.tf
+++ b/aws/modules/register/variables.tf
@@ -36,6 +36,14 @@ variable cdn_dns_zone_id {
   description = "hosted zone for CDN records"
 }
 
+variable paas_cdn_hosted_zone_id {
+  description = "hosted zone for CDN records"
+}
+
+variable paas_cdn_domain_name {
+  description = "CloudFront distribution name"
+}
+
 variable pingdom_contact_ids {
   description = "contacts to send state change notifications to"
 }

--- a/aws/registers/registers.tf
+++ b/aws/registers/registers.tf
@@ -11,6 +11,8 @@ module "address_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -27,6 +29,8 @@ module "academy-school-eng_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -43,6 +47,8 @@ module "clinical-commissioning-group_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -59,6 +65,8 @@ module "company_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -75,6 +83,8 @@ module "country_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -91,6 +101,8 @@ module "datatype_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -107,6 +119,8 @@ module "diocese_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -123,6 +137,8 @@ module "field_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -139,6 +155,8 @@ module "food-authority_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -155,6 +173,8 @@ module "food-premises_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -171,6 +191,8 @@ module "food-premises-rating_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -187,6 +209,8 @@ module "food-premises-type_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -203,6 +227,8 @@ module "green-deal-certification-body_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -219,6 +245,8 @@ module "government-domain_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -235,6 +263,8 @@ module "government-organisation_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -251,6 +281,8 @@ module "government-service_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -267,6 +299,8 @@ module "industrial-classification_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -283,6 +317,8 @@ module "internal-drainage-board_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -299,6 +335,8 @@ module "jobcentre_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -315,6 +353,8 @@ module "la-maintained-school-eng_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -331,6 +371,8 @@ module "local-authority-eng_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -347,6 +389,8 @@ module "local-authority-nir_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -363,6 +407,8 @@ module "local-authority-sct_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -379,6 +425,8 @@ module "local-authority-type_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -395,6 +443,8 @@ module "local-authority-wls_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -411,6 +461,8 @@ module "place_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -427,6 +479,8 @@ module "premises_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -443,6 +497,8 @@ module "principal-local-authority_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -459,6 +515,8 @@ module "prison_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -475,6 +533,8 @@ module "prison-estate_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -491,6 +551,8 @@ module "public-body_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -507,6 +569,8 @@ module "public-body-classification_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -523,6 +587,8 @@ module "occupation_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -539,6 +605,8 @@ module "register_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -555,6 +623,8 @@ module "registration-district_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -571,6 +641,8 @@ module "religious-character_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -587,6 +659,8 @@ module "school-admissions-policy_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -603,6 +677,8 @@ module "school-authority-eng_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -619,6 +695,8 @@ module "school-eng_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -635,6 +713,8 @@ module "school-gender_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -651,6 +731,8 @@ module "school-phase_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -667,6 +749,8 @@ module "school-tag_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -683,6 +767,8 @@ module "school-trust_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -699,6 +785,8 @@ module "school-type_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -715,6 +803,8 @@ module "social-housing-provider_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -731,6 +821,8 @@ module "social-housing-provider-designation_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -747,6 +839,8 @@ module "social-housing-provider-legal-entity_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -763,6 +857,8 @@ module "statistical-geography_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -779,6 +875,8 @@ module "statistical-geography-unitary-authority-wls_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -795,6 +893,8 @@ module "street_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -811,6 +911,8 @@ module "street-custodian_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -827,6 +929,8 @@ module "territory_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -843,6 +947,8 @@ module "uk_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
@@ -859,5 +965,7 @@ module "vehicle-colour_register" {
   cdn_configuration = "${var.cdn_configuration}"
   cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
   cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }


### PR DESCRIPTION
This will move away from our self-managed AWS infrastructure to PaaS.

Things to double-check before deploying: Terraform shows that this will be resource modifications. We need to double check that this isn't modelled as a delete/create so that we won't end up with any records that are unresolvable for a period of time.