### PR TITLE
Point `*.register.gov.uk` registers directly to PaaS

### DIFF
--- a/aws/modules/register/cdn.tf
+++ b/aws/modules/register/cdn.tf
@@ -55,7 +55,7 @@ resource "aws_cloudfront_distribution" "distribution" {
   }
 
   origin {
-    domain_name = "${aws_route53_record.record.fqdn}"
+    domain_name = "cloudapps.digital"
     origin_id = "${var.environment}-${var.name}-elb"
     custom_header {
       name = "X-Forwarded-Host",


### PR DESCRIPTION
We tried `*.register.gov.uk` at `*.openregister.org` and saw some
Cloudfront issues. Possibly related to running a Cloudfront distribution
in front of another Cloudfront distribution. This simplifies things and
just points registers on `gov.uk` directly to PaaS.