### PR TITLE
Allow additional methods on `*.*.openregister.org`

### DIFF
--- a/aws/registers/paas_cdn.tf
+++ b/aws/registers/paas_cdn.tf
@@ -13,7 +13,7 @@ resource "aws_cloudfront_distribution" "paas_cdn" {
   }
 
   default_cache_behavior {
-    allowed_methods = ["HEAD", "GET"]
+    allowed_methods = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
     cached_methods = ["HEAD", "GET"]
 
     default_ttl = 86400


### PR DESCRIPTION
These additional methods are required in order to make changes to a
deployed register.