### PR TITLE
Reduce CloudFront TTL to 60 seconds for *.openregister.org

### DIFF
--- a/aws/registers/paas_cdn.tf
+++ b/aws/registers/paas_cdn.tf
@@ -16,7 +16,7 @@ resource "aws_cloudfront_distribution" "paas_cdn" {
     allowed_methods = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
     cached_methods = ["HEAD", "GET"]
 
-    default_ttl = 86400
+    default_ttl = 60
     max_ttl = 31536000
     min_ttl = 0
 


### PR DESCRIPTION
As part of migrating to PaaS we introduced new CloudFront
distributions for the *.openregister.org domains. This means that
when we make updates to discovery and alpha environments the cache
does not invalidate for 24 hours. This is temporary solution so that
we can see updates immediately. In the near future we should do some
work to make our cache headers more intelligent. The register.gov.uk
domain will continue to cache for 24 hours.