### PR TITLE
Add government-domain and statistical-geography registers to beta

### DIFF
--- a/ansible/group_vars/tag_Environment_beta
+++ b/ansible/group_vars/tag_Environment_beta
@@ -23,6 +23,7 @@ register_groups:
 
   multi:
     - country
+    - government-domain
     - government-organisation
     - government-service
     - internal-drainage-board
@@ -32,4 +33,6 @@ register_groups:
     - principal-local-authority
     - prison-estate
     - registration-district
+    - statistical-geography
+    - statistical-geography-unitary-authority-wls
     - territory


### PR DESCRIPTION
This commit adds `government-domain`, `statistical-geography` and `statistical-geography-unitary-authority-wls` to beta