### PR TITLE
Set cache TTL to 0

### DIFF
--- a/aws/registers/paas_cdn.tf
+++ b/aws/registers/paas_cdn.tf
@@ -16,8 +16,8 @@ resource "aws_cloudfront_distribution" "paas_cdn" {
     allowed_methods = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
     cached_methods = ["HEAD", "GET"]
 
-    default_ttl = 60
-    max_ttl = 31536000
+    default_ttl = 0
+    max_ttl = 0
     min_ttl = 0
 
     forwarded_values {


### PR DESCRIPTION
When DFE are loading data they also query the same register later.
The 60s TTL means that they are getting stale results and putting
incorrect data into the register. This is temporary as we will
have to address the caching issues before they move to beta.