### PR TITLE
Trigger slack alerts from CodeBuild

### DIFF
--- a/aws/modules/codedeploy_group/main.tf
+++ b/aws/modules/codedeploy_group/main.tf
@@ -1,7 +1,3 @@
-resource "aws_sns_topic" "deployments" {
-  name = "deployments-${var.id}"
-}
-
 resource "aws_codedeploy_deployment_group" "codedeploy_group" {
   deployment_group_name = "${var.id}"
   app_name = "${var.application}"
@@ -11,11 +7,5 @@ resource "aws_codedeploy_deployment_group" "codedeploy_group" {
     key = "DeploymentGroup"
     type = "KEY_AND_VALUE"
     value = "${var.tag}"
-  }
-
-  trigger_configuration {
-    trigger_events = ["DeploymentStart", "DeploymentFailure", "DeploymentSuccess"]
-    trigger_name = "Send to Slack"
-    trigger_target_arn = "${aws_sns_topic.deployments.arn}"
   }
 }


### PR DESCRIPTION
This commit removes SNS topics of the form `registers-*` from being automatically created. In addition, it also removes triggers for the CodeDeploy groups that previously fired events to SNS topics when a deployment started, stopped, succeeded or failed.