### PR TITLE
Add social-housing-provider-eng registers

### DIFF
--- a/ansible/group_vars/tag_Environment_alpha
+++ b/ansible/group_vars/tag_Environment_alpha
@@ -28,5 +28,8 @@ register_groups:
     - school-eng
     - school-type-eng
     - social-housing-provider
+    - social-housing-provider-eng
     - social-housing-provider-designation
+    - social-housing-provider-designation-eng
     - social-housing-provider-legal-entity
+    - social-housing-provider-legal-entity-eng

--- a/aws/registers/registers.tf
+++ b/aws/registers/registers.tf
@@ -808,6 +808,24 @@ module "social-housing-provider_register" {
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
+module "social-housing-provider-eng_register" {
+  source = "../modules/register"
+  enabled = "${lookup(var.enabled_registers, "social-housing-provider-eng", false)}"
+
+  name = "social-housing-provider-eng"
+  environment = "${var.vpc_name}"
+  load_balancer = "${module.multi.load_balancer}"
+  dns_zone_id = "${module.core.dns_zone_id}"
+
+  enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
+  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
+  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
+  pingdom_contact_ids = "${var.pingdom_contact_ids}"
+}
+
 module "social-housing-provider-designation_register" {
   source = "../modules/register"
   enabled = "${lookup(var.enabled_registers, "social-housing-provider-designation", false)}"
@@ -826,11 +844,47 @@ module "social-housing-provider-designation_register" {
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
+module "social-housing-provider-designation-eng_register" {
+  source = "../modules/register"
+  enabled = "${lookup(var.enabled_registers, "social-housing-provider-designation-eng", false)}"
+
+  name = "social-housing-provider-designation-eng"
+  environment = "${var.vpc_name}"
+  load_balancer = "${module.multi.load_balancer}"
+  dns_zone_id = "${module.core.dns_zone_id}"
+
+  enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
+  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
+  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
+  pingdom_contact_ids = "${var.pingdom_contact_ids}"
+}
+
 module "social-housing-provider-legal-entity_register" {
   source = "../modules/register"
   enabled = "${lookup(var.enabled_registers, "social-housing-provider-legal-entity", false)}"
 
   name = "social-housing-provider-legal-entity"
+  environment = "${var.vpc_name}"
+  load_balancer = "${module.multi.load_balancer}"
+  dns_zone_id = "${module.core.dns_zone_id}"
+
+  enable_availability_checks = "${var.enable_availability_checks}"
+  cdn_configuration = "${var.cdn_configuration}"
+  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
+  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
+  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
+  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
+  pingdom_contact_ids = "${var.pingdom_contact_ids}"
+}
+
+module "social-housing-provider-legal-entity-eng_register" {
+  source = "../modules/register"
+  enabled = "${lookup(var.enabled_registers, "social-housing-provider-legal-entity-eng", false)}"
+
+  name = "social-housing-provider-legal-entity-eng"
   environment = "${var.vpc_name}"
   load_balancer = "${module.multi.load_balancer}"
   dns_zone_id = "${module.core.dns_zone_id}"


### PR DESCRIPTION
This commit adds `social-housing-provider-eng`, `social-housing-provider-designation-eng` and `social-housing-provider-legal-entity-eng` registers, which will replace `social-housing-provider`, `social-housing-provider-designation` and `social-housing-provider-legal-entity` respectively.