### PR TITLE
Do not generate RDS credentials

### DIFF
--- a/ansible/generate_passwords.yml
+++ b/ansible/generate_passwords.yml
@@ -23,10 +23,3 @@
         creates: "{{ pass_store_location | expanduser }}/{{ vpc }}/app/mint/{{ item }}.gpg"
       with_flattened:
         - "{{ register_groups.values() }}"
-
-    - name: Generate RDS passwords
-      command: "pass generate --no-symbols {{ vpc }}/rds/openregister/{{ item }} {{ password_length }}"
-      args:
-        creates: "{{ pass_store_location | expanduser }}/{{ vpc }}/rds/openregister/{{ item }}.gpg"
-      with_items:
-        - "{{ register_groups.keys() | union(['master']) }}"


### PR DESCRIPTION
Recently, RDS instances were removed as our databases now live on PaaS. Running `ansible-playbook generate_passwords.yml -e VPC=<env>` still generates RDS credentials, which this commit fixes.