### PR TITLE
Remove statistical-geography-council-area-sct from discovery

### DIFF
--- a/ansible/group_vars/tag_Environment_discovery
+++ b/ansible/group_vars/tag_Environment_discovery
@@ -44,5 +44,4 @@ register_groups:
     - qualification-level
     - qualification-subject
     - qualification-type
-    - statistical-geography-council-area-sct
     - westminster-parliamentary-constituency


### PR DESCRIPTION
This register now exists in alpha so no longer needs to exist in
discovery.