### PR TITLE
Add average response time and location as metrics to performance platform data

### DIFF
--- a/aws/lambda/python/pingdom-to-performance-platform/performance_platform.py
+++ b/aws/lambda/python/pingdom-to-performance-platform/performance_platform.py
@@ -98,16 +98,18 @@ def build_payload(pingdom, tag):
         timestamp = start_of_previous_hour.strftime("%Y-%m-%dT%H:00:00+00:00")
         uptime = summary["summary"]["status"]["totalup"]
         downtime = summary["summary"]["status"]["totaldown"]
+        responsetime = summary["summary"]["responsetime"]["avgresponse"]
         payload.append({
             "_timestamp": timestamp,
             "service": "govuk-registers",
             "check": "govuk-registers-{}-{}-{}".format(phase, register, location),
+            "location": location,
             "period": "hour",
             "downtime": downtime,
-            "uptime": uptime
+            "uptime": uptime,
+            "responsetime": responsetime
             })
-
-        print("{}\t{}\t{}\t{}\t{}\t{}".format(timestamp, phase, register, location, downtime, uptime))
+        print("{}\t{}\t{}\t{}\t{}\t{}\t{}".format(timestamp, phase, register, location, downtime, uptime, responsetime))
 
     return payload
 

--- a/aws/lambda/python/pingdom-to-performance-platform/test/test_performance_platform.py
+++ b/aws/lambda/python/pingdom-to-performance-platform/test/test_performance_platform.py
@@ -11,16 +11,20 @@ EXPECTED_PAYLOAD = [{
     "_timestamp": "2017-05-08T10:00:00+00:00",
     "service": "govuk-registers",
     "check": "govuk-registers-beta-register-name-cdn",
+    "location": "cdn",
     "period": "hour",
     "downtime": 20,
-    "uptime": 3580
+    "uptime": 3580,
+    "responsetime": 331
 }, {
     "_timestamp": "2017-05-08T10:00:00+00:00",
     "service": "govuk-registers",
     "check": "govuk-registers-beta-register-name-origin",
+    "location": "origin",
     "period": "hour",
     "downtime": 10,
-    "uptime": 3590
+    "uptime": 3590,
+    "responsetime": 718
 }]
 
 FAKE_PINGDOM_CHECKS_RESPONSE = {
@@ -63,6 +67,9 @@ FAKE_PINGDOM_CHECKS_RESPONSE = {
 
 FAKE_CDN_PERFORMANCE_RESPONSE = {
   "summary": {
+    "responsetime": {
+      "avgresponse": 331
+    },
     "status": {
       "totaldown": 20,
       "totalunknown": 0,
@@ -73,6 +80,9 @@ FAKE_CDN_PERFORMANCE_RESPONSE = {
 
 FAKE_ORIGIN_PERFORMANCE_RESPONSE = {
   "summary": {
+    "responsetime": {
+      "avgresponse": 718
+    },
     "status": {
       "totaldown": 10,
       "totalunknown": 0,


### PR DESCRIPTION
This PR adds two new metrics - `responsetime` (from the `avgresponse` provided by Pingdom) and `location` - which will be sent alongside the existing payload to the Performance Platform. Splitting out `location` from the name of the check will make filtering easier, whilst `responsetime` is added to as additional data to display on the report.