### PR TITLE
Rename public-body registers

### DIFF
--- a/ansible/group_vars/tag_Environment_alpha
+++ b/ansible/group_vars/tag_Environment_alpha
@@ -24,8 +24,8 @@ register_groups:
     - local-authority-nir
     - occupation
     - principal-local-authority
-    - public-body
-    - public-body-classification
+    - public-body-account
+    - public-body-account-classification
     - school-eng
     - school-type-eng
     - social-housing-provider

--- a/aws/registers/registers.tf
+++ b/aws/registers/registers.tf
@@ -661,11 +661,11 @@ module "prison-estate_register" {
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
-module "public-body_register" {
+module "public-body-account_register" {
   source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "public-body", false)}"
+  enabled = "${lookup(var.enabled_registers, "public-body-account", false)}"
 
-  name = "public-body"
+  name = "public-body-account"
   environment = "${var.environment_name}"
   dns_zone_id = "${module.core.dns_zone_id}"
 
@@ -678,11 +678,11 @@ module "public-body_register" {
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
-module "public-body-classification_register" {
+module "public-body-account-classification_register" {
   source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "public-body-classification", false)}"
+  enabled = "${lookup(var.enabled_registers, "public-body-account-classification", false)}"
 
-  name = "public-body-classification"
+  name = "public-body-account-classification"
   environment = "${var.environment_name}"
   dns_zone_id = "${module.core.dns_zone_id}"
 


### PR DESCRIPTION
### Context
The public-body custodian has agreed to rename the public-body registers

### Changes proposed in this pull request
- public-body becomes public-body-account
- public-body-classification becomes public-body-account-classification

### Guidance to review
On updating `alpha.tfvars` this should delete public-body and public-body-classification and create public-body-account and public-body-account-classification.