### PR TITLE
Create local-authority-nir register in beta

### DIFF
--- a/ansible/group_vars/tag_Environment_beta
+++ b/ansible/group_vars/tag_Environment_beta
@@ -28,6 +28,7 @@ register_groups:
     - government-service
     - internal-drainage-board
     - local-authority-eng
+    - local-authority-nir
     - local-authority-sct
     - local-authority-type
     - principal-local-authority


### PR DESCRIPTION
### Context
We have approval to promote local-authority-nir from alpha to beta.

### Changes proposed in this pull request
Create local-authority-nir in beta. We will leave it running in alpha until the beta register is running, then remove the alpha one.

### Guidance to review
This only needs to be added to the ansible config since it already exists in `registers.tf`.