### PR TITLE
Remove registers that have been promoted to other phases

### DIFF
--- a/ansible/group_vars/tag_Environment_alpha
+++ b/ansible/group_vars/tag_Environment_alpha
@@ -21,18 +21,13 @@ register_groups:
   multi:
     - allergen
     - industrial-classification
-    - local-authority-nir
     - occupation
-    - principal-local-authority
     - public-body-account
     - public-body-account-classification
     - school-eng
     - school-type-eng
-    - social-housing-provider
     - social-housing-provider-eng
-    - social-housing-provider-designation
     - social-housing-provider-designation-eng
-    - social-housing-provider-legal-entity
     - social-housing-provider-legal-entity-eng
     - statistical-geography-council-area-sct
     - statistical-geography-county-eng

--- a/ansible/group_vars/tag_Environment_discovery
+++ b/ansible/group_vars/tag_Environment_discovery
@@ -26,8 +26,6 @@ register_groups:
     - clinical-commissioning-group
     - green-deal-certification-body
     - jobcentre
-    - local-authority-nir
-    - local-authority-type
     - meat-establishment-operation
     - meat-establishment-outcome
     - meat-establishment-type

--- a/aws/registers/registers.tf
+++ b/aws/registers/registers.tf
@@ -967,23 +967,6 @@ module "school-type-eng_register" {
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
-module "social-housing-provider_register" {
-  source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "social-housing-provider", false)}"
-
-  name = "social-housing-provider"
-  environment = "${var.environment_name}"
-  dns_zone_id = "${module.core.dns_zone_id}"
-
-  enable_availability_checks = "${var.enable_availability_checks}"
-  cdn_configuration = "${var.cdn_configuration}"
-  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
-  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
-  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
-  pingdom_contact_ids = "${var.pingdom_contact_ids}"
-}
-
 module "social-housing-provider-eng_register" {
   source = "../modules/register"
   enabled = "${lookup(var.enabled_registers, "social-housing-provider-eng", false)}"
@@ -1001,45 +984,11 @@ module "social-housing-provider-eng_register" {
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
-module "social-housing-provider-designation_register" {
-  source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "social-housing-provider-designation", false)}"
-
-  name = "social-housing-provider-designation"
-  environment = "${var.environment_name}"
-  dns_zone_id = "${module.core.dns_zone_id}"
-
-  enable_availability_checks = "${var.enable_availability_checks}"
-  cdn_configuration = "${var.cdn_configuration}"
-  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
-  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
-  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
-  pingdom_contact_ids = "${var.pingdom_contact_ids}"
-}
-
 module "social-housing-provider-designation-eng_register" {
   source = "../modules/register"
   enabled = "${lookup(var.enabled_registers, "social-housing-provider-designation-eng", false)}"
 
   name = "social-housing-provider-designation-eng"
-  environment = "${var.environment_name}"
-  dns_zone_id = "${module.core.dns_zone_id}"
-
-  enable_availability_checks = "${var.enable_availability_checks}"
-  cdn_configuration = "${var.cdn_configuration}"
-  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
-  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
-  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
-  pingdom_contact_ids = "${var.pingdom_contact_ids}"
-}
-
-module "social-housing-provider-legal-entity_register" {
-  source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "social-housing-provider-legal-entity", false)}"
-
-  name = "social-housing-provider-legal-entity"
   environment = "${var.environment_name}"
   dns_zone_id = "${module.core.dns_zone_id}"
 


### PR DESCRIPTION
### Context
Remove registers that have been promoted to other phases.

### Changes proposed in this pull request
Remove from discovery:
- local-authority-nir
- local-authority-type

Remove from alpha:
- local-authority-nir
- principal-local-authority
- social-housing-provider
- social-housing-provider-designation
- social-housing-provider-legal-entity

### Guidance to review
Registers either exist in other phases or have been renamed with `-eng` suffixes.