### PR TITLE
Move discovery environment to be auto deployed with test

### DIFF
--- a/aws/pipeline/openregister-java_pipeline.tf
+++ b/aws/pipeline/openregister-java_pipeline.tf
@@ -98,7 +98,7 @@ resource "aws_codepipeline" "pipeline" {
   }
 
   stage {
-    name = "DeployToTest"
+    name = "DeployToTestAndDiscovery"
 
     action {
       name = "deploy-test-basic"
@@ -127,22 +127,6 @@ resource "aws_codepipeline" "pipeline" {
         ProjectName = "${module.test_multi.name}"
       }
     }
-  }
-
-  stage {
-    name = "AlphaAndDiscoveryApproval"
-
-    action {
-      name = "DeployToAlphaAndDiscoveryProduction"
-      category = "Approval"
-      owner = "AWS"
-      provider = "Manual"
-      version = "1"
-    }
-  }
-
-  stage {
-    name = "DeployToAlphaAndDiscovery"
 
     action {
       name = "deploy-discovery-basic"
@@ -171,6 +155,22 @@ resource "aws_codepipeline" "pipeline" {
         ProjectName = "${module.discovery_multi.name}"
       }
     }
+  }
+
+  stage {
+    name = "AlphaApproval"
+
+    action {
+      name = "DeployToAlphaProduction"
+      category = "Approval"
+      owner = "AWS"
+      provider = "Manual"
+      version = "1"
+    }
+  }
+
+  stage {
+    name = "DeployToAlpha"
 
     action {
       name = "deploy-alpha-basic"


### PR DESCRIPTION
### Context

This commit moves the `discovery` environment into the auto-deployment group, along `test` environment. The reason for this change is to make it easier for the register creation team members to spin up a new register for feedback.

### Changes proposed in this pull request

Update `CodePipeline` to auto-deploy `discovery` environment on a new push of ORJ.

### Guidance to review

You'll need to run `make plan` to see changes.
