### PR TITLE
Update domain for discovery environment

### DIFF
--- a/ansible/group_vars/tag_Environment_discovery
+++ b/ansible/group_vars/tag_Environment_discovery
@@ -1,4 +1,4 @@
-register_domain: discovery.openregister.org
+register_domain: cloudapps.digital
 
 enable_register_data_delete: true
 


### PR DESCRIPTION
### Context
We are now using cloudapps.digital for the discovery environment
instead of discovery.openregister.org.

### Changes proposed in this pull request
Update `paas-config.yaml` to specify the correct domain. This ensures registers
in that environment link to each other correctly.

### Guidance to review
This should add `registerDomain: cloudapps.digital` to `paas-config.yaml` for discovery registers when running `upload_configs_to_s3.yml` (can be tested by changing `sync:false` in that file and checking the local `config` directory).