### PR TITLE
Remove police registers from discovery

### DIFF
--- a/ansible/group_vars/tag_Environment_discovery
+++ b/ansible/group_vars/tag_Environment_discovery
@@ -27,8 +27,6 @@ register_groups:
     - charity-class
     - clinical-commissioning-group
     - place
-    - police-force
-    - police-neighbourhood
     - prison
     - street
     - street-custodian

--- a/aws/registers/registers.tf
+++ b/aws/registers/registers.tf
@@ -508,40 +508,6 @@ module "place_register" {
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
-module "police-force_register" {
-  source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "police-force", false)}"
-
-  name = "police-force"
-  environment = "${var.environment_name}"
-  dns_zone_id = "${module.core.dns_zone_id}"
-
-  enable_availability_checks = "${var.enable_availability_checks}"
-  cdn_configuration = "${var.cdn_configuration}"
-  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
-  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
-  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
-  pingdom_contact_ids = "${var.pingdom_contact_ids}"
-}
-
-module "police-neighbourhood_register" {
-  source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "police-neighbourhood", false)}"
-
-  name = "police-neighbourhood"
-  environment = "${var.environment_name}"
-  dns_zone_id = "${module.core.dns_zone_id}"
-
-  enable_availability_checks = "${var.enable_availability_checks}"
-  cdn_configuration = "${var.cdn_configuration}"
-  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
-  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
-  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
-  pingdom_contact_ids = "${var.pingdom_contact_ids}"
-}
-
 module "premises_register" {
   source = "../modules/register"
   enabled = "${lookup(var.enabled_registers, "premises", false)}"


### PR DESCRIPTION
### Context
This PR removes `police-force` and `police-neighbourhood` from `discovery`.

