### PR TITLE
Remove Slack integration from data load scripts

### DIFF
--- a/scripts/includes/slack-notify.sh
+++ b/scripts/includes/slack-notify.sh
@@ -1,8 +1,0 @@
-SLACK_PATH=`PASSWORD_STORE_DIR=~/.registers-pass pass services/slack/rda-team-incoming-webhook`
-
-function notify_slack()
-{
-  echo ""
-  echo "Slack: $1"
-  curl -X POST -H 'Content-type: application/json' --data "{'text':'$1'}" "https://hooks.slack.com/services/$SLACK_PATH"
-}

--- a/scripts/load-register-tsv.sh
+++ b/scripts/load-register-tsv.sh
@@ -4,7 +4,6 @@ OPENREGISTER_BASE="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
 echo "OPENREGISTER_BASE - $OPENREGISTER_BASE"
 
 source "$OPENREGISTER_BASE/deployment/scripts/includes/git-update.sh"
-source "$OPENREGISTER_BASE/deployment/scripts/includes/slack-notify.sh"
 source "$OPENREGISTER_BASE/deployment/scripts/includes/register-actions.sh"
 source "$OPENREGISTER_BASE/deployment/scripts/includes/set-vars.sh"
 

--- a/scripts/reload-metadata-yaml.sh
+++ b/scripts/reload-metadata-yaml.sh
@@ -5,7 +5,6 @@ echo "OPENREGISTER_BASE - $OPENREGISTER_BASE"
 
 source "$OPENREGISTER_BASE/deployment/scripts/includes/set-vars.sh"
 source "$OPENREGISTER_BASE/deployment/scripts/includes/git-update.sh"
-source "$OPENREGISTER_BASE/deployment/scripts/includes/slack-notify.sh"
 source "$OPENREGISTER_BASE/deployment/scripts/includes/register-actions.sh"
 
 usage()

--- a/scripts/update-metadata-yaml.sh
+++ b/scripts/update-metadata-yaml.sh
@@ -5,7 +5,6 @@ echo "OPENREGISTER_BASE - $OPENREGISTER_BASE"
 
 source "$OPENREGISTER_BASE/deployment/scripts/includes/set-vars.sh"
 source "$OPENREGISTER_BASE/deployment/scripts/includes/git-update.sh"
-source "$OPENREGISTER_BASE/deployment/scripts/includes/slack-notify.sh"
 source "$OPENREGISTER_BASE/deployment/scripts/includes/register-actions.sh"
 
 usage()

--- a/scripts/update-register-tsv.sh
+++ b/scripts/update-register-tsv.sh
@@ -5,7 +5,6 @@ echo "OPENREGISTER_BASE - $OPENREGISTER_BASE"
 
 source "$OPENREGISTER_BASE/deployment/scripts/includes/set-vars.sh"
 source "$OPENREGISTER_BASE/deployment/scripts/includes/git-update.sh"
-source "$OPENREGISTER_BASE/deployment/scripts/includes/slack-notify.sh"
 source "$OPENREGISTER_BASE/deployment/scripts/includes/register-actions.sh"
 
 usage()


### PR DESCRIPTION
### Context
We used to notify Slack each time an update was made to a register
via these scripts. We no longer use the slack channel and I've
confirmed that the Slack notifications are no longer required.

### Changes proposed in this pull request
Remove Slack integration.

### Guidance to review
