### PR TITLE
Update register load scripts to use new discovery URLS

### DIFF
--- a/scripts/includes/register-actions.sh
+++ b/scripts/includes/register-actions.sh
@@ -1,22 +1,32 @@
+function get_register_url() {
+  local register=$1
+  local phase=$2
+  case $phase in
+    'beta'|'alpha'|'test') echo https://$register.$phase.openregister.org;;
+    'discovery') echo https://$register.cloudapps.digital;;
+  esac
+}
+
 function delete_register()
 {
   local register=$1
   local phase=$2
   local password=$3
+  local register_url=$(get_register_url $register $phase)
   echo ""
   echo -n "Delete existing $register data from $phase register? (y/n)? "
   read answer
   if echo "$answer" | grep -iq "^y" ; then
       echo "Deleting $register data from $phase $register"
       for i in `seq 1 20`; do
-          curl -X DELETE -u openregister:$password https://$register.$phase.openregister.org/delete-register-data
+          curl -X DELETE -u openregister:$password $register_url/delete-register-data
           echo " - request: $i of 20"
       done
 
       echo ""
       echo "Testing consistency of instances"
       for i in `seq 1 20`; do
-          register_proof=$(curl -s https://$register.$phase.openregister.org/proof/register/merkle:sha-256)
+          register_proof=$(curl -s $register_url/proof/register/merkle:sha-256)
           if [[ $register_proof != *"sha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"* ]]; then
               echo "Root hash from one of the instances is not empty - exiting..."
               exit 1
@@ -30,12 +40,13 @@ function load_rsf()
   local register=$1
   local phase=$2
   local password=$3
+  local register_url=$(get_register_url $register $phase)
   echo ""
   echo -n "Load $register data into $phase register? (y/n)? "
   read answer
   if echo "$answer" | grep -iq "^y" ; then
     echo ""
     echo "Loading $register data to $phase"
-    echo `cat $OPENREGISTER_BASE/tmp.rsf | curl -X POST -u openregister:$password --data-binary @- https://$register.$phase.openregister.org/load-rsf --header "Content-Type:application/uk-gov-rsf"`
+    echo `cat $OPENREGISTER_BASE/tmp.rsf | curl -X POST -u openregister:$password --data-binary @- $register_url/load-rsf --header "Content-Type:application/uk-gov-rsf"`
   fi
 }

--- a/scripts/rsfcreator.py
+++ b/scripts/rsfcreator.py
@@ -7,6 +7,12 @@ import argparse
 import hashlib
 import requests
 
+def get_register_url(register, phase):
+    if phase in ['beta', 'alpha', 'test']:
+        return 'https://{0}.{1}.openregister.org'.format(register, phase)
+    elif phase == 'discovery':
+        return 'https://{0}.cloudapps.digital'.format(register)
+
 def remove_blanks(dic):
     return {k: v for k, v in dic.items() if v }
 
@@ -38,11 +44,11 @@ def read_item_from_local(file_name):
     return dic
 
 def read_register_from_register(phase, register_name):
-    register_url= 'http://register.{0}.openregister.org/record/{1}.json'.format(phase, register_name)
+    register_url= '{0}/record/{1}.json'.format(get_register_url('register', phase), register_name)
     return read_item_from_register(register_url, register_name)
 
 def read_field_from_register(phase, field_name):
-    field_url= 'http://field.{0}.openregister.org/record/{1}.json'.format(phase, field_name)
+    field_url= '{0}/record/{1}.json'.format(get_register_url('field', phase), field_name)
     return read_item_from_register(field_url, field_name)
 
 def read_item_from_register(url, field_name):


### PR DESCRIPTION
### Context
We have moved discovery registers from *.discovery.openregister.org to *.cloudapps.digital.

### Changes proposed in this pull request
These scripts have been updated to load data to the correct location.

### Guidance to review
Loading data to all environments should still work.
Tests should still pass `python3 -m unittest rsfcreator_test.py`