### PR TITLE
Add qualification registers to beta

### DIFF
--- a/ansible/group_vars/tag_Environment_beta
+++ b/ansible/group_vars/tag_Environment_beta
@@ -37,6 +37,10 @@ register_groups:
     - local-authority-type
     - principal-local-authority
     - prison-estate
+    - qualification-assessment-method
+    - qualification-level
+    - qualification-sector-subject-area
+    - qualification-type
     - registration-district
     - statistical-geography
     - statistical-geography-county-eng


### PR DESCRIPTION
This PR adds `qualification-assessment-method`, `qualification-level`, `qualification-sector-subject-area` and `qualification-type` registers to beta.