### PR TITLE
Remove registers from alpha

### DIFF
--- a/ansible/group_vars/tag_Environment_alpha
+++ b/ansible/group_vars/tag_Environment_alpha
@@ -19,9 +19,6 @@ register_groups:
     - field
 
   multi:
-    - jobcentre
-    - jobcentre-district
-    - jobcentre-group
     - occupation
     - public-body-account
     - public-body-account-classification
@@ -35,4 +32,3 @@ register_groups:
     - social-housing-provider-designation-eng
     - social-housing-provider-legal-entity-eng
     - statistical-geography-council-area-sct
-    - statistical-geography-local-government-district-nir


### PR DESCRIPTION
### Context
Because they have been promoted to beta.

### Changes proposed in this pull request
Remove from alpha:
- statistical-geography-local-government-district-nir
- jobcentre
- jobcentre-district
- jobcentre-group