### PR TITLE
Clean-up registers.tf

### DIFF
--- a/aws/registers/registers.tf
+++ b/aws/registers/registers.tf
@@ -1,110 +1,8 @@
-module "address_register" {
-  source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "address", false)}"
-
-  name = "address"
-  environment = "${var.environment_name}"
-  dns_zone_id = "${module.core.dns_zone_id}"
-
-  enable_availability_checks = "${var.enable_availability_checks}"
-  cdn_configuration = "${var.cdn_configuration}"
-  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
-  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
-  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
-  pingdom_contact_ids = "${var.pingdom_contact_ids}"
-}
-
-module "academy-school-eng_register" {
-  source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "academy-school-eng", false)}"
-
-  name = "academy-school-eng"
-  environment = "${var.environment_name}"
-  dns_zone_id = "${module.core.dns_zone_id}"
-
-  enable_availability_checks = "${var.enable_availability_checks}"
-  cdn_configuration = "${var.cdn_configuration}"
-  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
-  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
-  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
-  pingdom_contact_ids = "${var.pingdom_contact_ids}"
-}
-
 module "allergen_register" {
   source = "../modules/register"
   enabled = "${lookup(var.enabled_registers, "allergen", false)}"
 
   name = "allergen"
-  environment = "${var.environment_name}"
-  dns_zone_id = "${module.core.dns_zone_id}"
-
-  enable_availability_checks = "${var.enable_availability_checks}"
-  cdn_configuration = "${var.cdn_configuration}"
-  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
-  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
-  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
-  pingdom_contact_ids = "${var.pingdom_contact_ids}"
-}
-
-module "charity" {
-  source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "charity", false)}"
-
-  name = "charity"
-  environment = "${var.environment_name}"
-  dns_zone_id = "${module.core.dns_zone_id}"
-
-  enable_availability_checks = "${var.enable_availability_checks}"
-  cdn_configuration = "${var.cdn_configuration}"
-  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
-  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
-  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
-  pingdom_contact_ids = "${var.pingdom_contact_ids}"
-}
-
-module "charity-class" {
-  source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "charity-class", false)}"
-
-  name = "charity-class"
-  environment = "${var.environment_name}"
-  dns_zone_id = "${module.core.dns_zone_id}"
-
-  enable_availability_checks = "${var.enable_availability_checks}"
-  cdn_configuration = "${var.cdn_configuration}"
-  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
-  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
-  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
-  pingdom_contact_ids = "${var.pingdom_contact_ids}"
-}
-
-module "clinical-commissioning-group_register" {
-  source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "clinical-commissioning-group", false)}"
-
-  name = "clinical-commissioning-group"
-  environment = "${var.environment_name}"
-  dns_zone_id = "${module.core.dns_zone_id}"
-
-  enable_availability_checks = "${var.enable_availability_checks}"
-  cdn_configuration = "${var.cdn_configuration}"
-  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
-  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
-  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
-  pingdom_contact_ids = "${var.pingdom_contact_ids}"
-}
-
-module "company_register" {
-  source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "company", false)}"
-
-  name = "company"
   environment = "${var.environment_name}"
   dns_zone_id = "${module.core.dns_zone_id}"
 
@@ -151,23 +49,6 @@ module "datatype_register" {
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
-module "diocese_register" {
-  source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "diocese", false)}"
-
-  name = "diocese"
-  environment = "${var.environment_name}"
-  dns_zone_id = "${module.core.dns_zone_id}"
-
-  enable_availability_checks = "${var.enable_availability_checks}"
-  cdn_configuration = "${var.cdn_configuration}"
-  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
-  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
-  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
-  pingdom_contact_ids = "${var.pingdom_contact_ids}"
-}
-
 module "field_register" {
   source = "../modules/register"
   enabled = "${lookup(var.enabled_registers, "field", false)}"
@@ -185,62 +66,11 @@ module "field_register" {
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
-module "food-authority_register" {
+module "fire-authority_register" {
   source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "food-authority", false)}"
+  enabled = "${lookup(var.enabled_registers, "fire-authority", false)}"
 
-  name = "food-authority"
-  environment = "${var.environment_name}"
-  dns_zone_id = "${module.core.dns_zone_id}"
-
-  enable_availability_checks = "${var.enable_availability_checks}"
-  cdn_configuration = "${var.cdn_configuration}"
-  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
-  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
-  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
-  pingdom_contact_ids = "${var.pingdom_contact_ids}"
-}
-
-module "food-premises_register" {
-  source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "food-premises", false)}"
-
-  name = "food-premises"
-  environment = "${var.environment_name}"
-  dns_zone_id = "${module.core.dns_zone_id}"
-
-  enable_availability_checks = "${var.enable_availability_checks}"
-  cdn_configuration = "${var.cdn_configuration}"
-  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
-  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
-  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
-  pingdom_contact_ids = "${var.pingdom_contact_ids}"
-}
-
-module "food-premises-rating_register" {
-  source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "food-premises-rating", false)}"
-
-  name = "food-premises-rating"
-  environment = "${var.environment_name}"
-  dns_zone_id = "${module.core.dns_zone_id}"
-
-  enable_availability_checks = "${var.enable_availability_checks}"
-  cdn_configuration = "${var.cdn_configuration}"
-  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
-  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
-  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
-  pingdom_contact_ids = "${var.pingdom_contact_ids}"
-}
-
-module "food-premises-type_register" {
-  source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "food-premises-type", false)}"
-
-  name = "food-premises-type"
+  name = "fire-authority"
   environment = "${var.environment_name}"
   dns_zone_id = "${module.core.dns_zone_id}"
 
@@ -372,23 +202,6 @@ module "jobcentre-group_register" {
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
-module "la-maintained-school-eng_register" {
-  source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "la-maintained-school-eng", false)}"
-
-  name = "la-maintained-school-eng"
-  environment = "${var.environment_name}"
-  dns_zone_id = "${module.core.dns_zone_id}"
-
-  enable_availability_checks = "${var.enable_availability_checks}"
-  cdn_configuration = "${var.cdn_configuration}"
-  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
-  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
-  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
-  pingdom_contact_ids = "${var.pingdom_contact_ids}"
-}
-
 module "local-authority-eng_register" {
   source = "../modules/register"
   enabled = "${lookup(var.enabled_registers, "local-authority-eng", false)}"
@@ -457,79 +270,11 @@ module "local-authority-type_register" {
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
-module "local-authority-wls_register" {
-  source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "local-authority-wls", false)}"
-
-  name = "local-authority-wls"
-  environment = "${var.environment_name}"
-  dns_zone_id = "${module.core.dns_zone_id}"
-
-  enable_availability_checks = "${var.enable_availability_checks}"
-  cdn_configuration = "${var.cdn_configuration}"
-  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
-  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
-  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
-  pingdom_contact_ids = "${var.pingdom_contact_ids}"
-}
-
-module "place_register" {
-  source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "place", false)}"
-
-  name = "place"
-  environment = "${var.environment_name}"
-  dns_zone_id = "${module.core.dns_zone_id}"
-
-  enable_availability_checks = "${var.enable_availability_checks}"
-  cdn_configuration = "${var.cdn_configuration}"
-  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
-  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
-  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
-  pingdom_contact_ids = "${var.pingdom_contact_ids}"
-}
-
-module "premises_register" {
-  source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "premises", false)}"
-
-  name = "premises"
-  environment = "${var.environment_name}"
-  dns_zone_id = "${module.core.dns_zone_id}"
-
-  enable_availability_checks = "${var.enable_availability_checks}"
-  cdn_configuration = "${var.cdn_configuration}"
-  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
-  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
-  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
-  pingdom_contact_ids = "${var.pingdom_contact_ids}"
-}
-
 module "principal-local-authority_register" {
   source = "../modules/register"
   enabled = "${lookup(var.enabled_registers, "principal-local-authority", false)}"
 
   name = "principal-local-authority"
-  environment = "${var.environment_name}"
-  dns_zone_id = "${module.core.dns_zone_id}"
-
-  enable_availability_checks = "${var.enable_availability_checks}"
-  cdn_configuration = "${var.cdn_configuration}"
-  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
-  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
-  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
-  pingdom_contact_ids = "${var.pingdom_contact_ids}"
-}
-
-module "prison_register" {
-  source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "prison", false)}"
-
-  name = "prison"
   environment = "${var.environment_name}"
   dns_zone_id = "${module.core.dns_zone_id}"
 
@@ -712,130 +457,11 @@ module "registration-district_register" {
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
-module "religious-character_register" {
-  source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "religious-character", false)}"
-
-  name = "religious-character"
-  environment = "${var.environment_name}"
-  dns_zone_id = "${module.core.dns_zone_id}"
-
-  enable_availability_checks = "${var.enable_availability_checks}"
-  cdn_configuration = "${var.cdn_configuration}"
-  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
-  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
-  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
-  pingdom_contact_ids = "${var.pingdom_contact_ids}"
-}
-
-module "school-admissions-policy_register" {
-  source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "school-admissions-policy", false)}"
-
-  name = "school-admissions-policy"
-  environment = "${var.environment_name}"
-  dns_zone_id = "${module.core.dns_zone_id}"
-
-  enable_availability_checks = "${var.enable_availability_checks}"
-  cdn_configuration = "${var.cdn_configuration}"
-  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
-  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
-  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
-  pingdom_contact_ids = "${var.pingdom_contact_ids}"
-}
-
-module "school-authority-eng_register" {
-  source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "school-authority-eng", false)}"
-
-  name = "school-authority-eng"
-  environment = "${var.environment_name}"
-  dns_zone_id = "${module.core.dns_zone_id}"
-
-  enable_availability_checks = "${var.enable_availability_checks}"
-  cdn_configuration = "${var.cdn_configuration}"
-  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
-  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
-  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
-  pingdom_contact_ids = "${var.pingdom_contact_ids}"
-}
-
 module "school-eng_register" {
   source = "../modules/register"
   enabled = "${lookup(var.enabled_registers, "school-eng", false)}"
 
   name = "school-eng"
-  environment = "${var.environment_name}"
-  dns_zone_id = "${module.core.dns_zone_id}"
-
-  enable_availability_checks = "${var.enable_availability_checks}"
-  cdn_configuration = "${var.cdn_configuration}"
-  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
-  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
-  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
-  pingdom_contact_ids = "${var.pingdom_contact_ids}"
-}
-
-module "school-gender_register" {
-  source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "school-gender", false)}"
-
-  name = "school-gender"
-  environment = "${var.environment_name}"
-  dns_zone_id = "${module.core.dns_zone_id}"
-
-  enable_availability_checks = "${var.enable_availability_checks}"
-  cdn_configuration = "${var.cdn_configuration}"
-  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
-  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
-  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
-  pingdom_contact_ids = "${var.pingdom_contact_ids}"
-}
-
-module "school-phase_register" {
-  source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "school-phase", false)}"
-
-  name = "school-phase"
-  environment = "${var.environment_name}"
-  dns_zone_id = "${module.core.dns_zone_id}"
-
-  enable_availability_checks = "${var.enable_availability_checks}"
-  cdn_configuration = "${var.cdn_configuration}"
-  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
-  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
-  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
-  pingdom_contact_ids = "${var.pingdom_contact_ids}"
-}
-
-module "school-tag_register" {
-  source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "school-tag", false)}"
-
-  name = "school-tag"
-  environment = "${var.environment_name}"
-  dns_zone_id = "${module.core.dns_zone_id}"
-
-  enable_availability_checks = "${var.enable_availability_checks}"
-  cdn_configuration = "${var.cdn_configuration}"
-  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
-  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
-  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
-  pingdom_contact_ids = "${var.pingdom_contact_ids}"
-}
-
-module "school-trust_register" {
-  source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "school-trust", false)}"
-
-  name = "school-trust"
   environment = "${var.environment_name}"
   dns_zone_id = "${module.core.dns_zone_id}"
 
@@ -1103,96 +729,11 @@ module "statistical-geography-unitary-authority-wls_register" {
   pingdom_contact_ids = "${var.pingdom_contact_ids}"
 }
 
-module "fire-authority_register" {
-  source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "fire-authority", false)}"
-
-  name = "fire-authority"
-  environment = "${var.environment_name}"
-  dns_zone_id = "${module.core.dns_zone_id}"
-
-  enable_availability_checks = "${var.enable_availability_checks}"
-  cdn_configuration = "${var.cdn_configuration}"
-  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
-  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
-  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
-  pingdom_contact_ids = "${var.pingdom_contact_ids}"
-}
-
-module "street_register" {
-  source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "street", false)}"
-
-  name = "street"
-  environment = "${var.environment_name}"
-  dns_zone_id = "${module.core.dns_zone_id}"
-
-  enable_availability_checks = "${var.enable_availability_checks}"
-  cdn_configuration = "${var.cdn_configuration}"
-  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
-  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
-  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
-  pingdom_contact_ids = "${var.pingdom_contact_ids}"
-}
-
-module "street-custodian_register" {
-  source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "street-custodian", false)}"
-
-  name = "street-custodian"
-  environment = "${var.environment_name}"
-  dns_zone_id = "${module.core.dns_zone_id}"
-
-  enable_availability_checks = "${var.enable_availability_checks}"
-  cdn_configuration = "${var.cdn_configuration}"
-  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
-  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
-  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
-  pingdom_contact_ids = "${var.pingdom_contact_ids}"
-}
-
 module "territory_register" {
   source = "../modules/register"
   enabled = "${lookup(var.enabled_registers, "territory", false)}"
 
   name = "territory"
-  environment = "${var.environment_name}"
-  dns_zone_id = "${module.core.dns_zone_id}"
-
-  enable_availability_checks = "${var.enable_availability_checks}"
-  cdn_configuration = "${var.cdn_configuration}"
-  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
-  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
-  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
-  pingdom_contact_ids = "${var.pingdom_contact_ids}"
-}
-
-module "uk_register" {
-  source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "uk", false)}"
-
-  name = "uk"
-  environment = "${var.environment_name}"
-  dns_zone_id = "${module.core.dns_zone_id}"
-
-  enable_availability_checks = "${var.enable_availability_checks}"
-  cdn_configuration = "${var.cdn_configuration}"
-  cdn_s3_origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
-  cdn_dns_zone_id = "${module.core.cdn_dns_zone_id}"
-  paas_cdn_domain_name = "${aws_cloudfront_distribution.paas_cdn.domain_name}"
-  paas_cdn_hosted_zone_id = "${aws_cloudfront_distribution.paas_cdn.hosted_zone_id}"
-  pingdom_contact_ids = "${var.pingdom_contact_ids}"
-}
-
-module "westminster-parliamentary-constituency_register" {
-  source = "../modules/register"
-  enabled = "${lookup(var.enabled_registers, "westminster-parliamentary-constituency", false)}"
-
-  name = "westminster-parliamentary-constituency"
   environment = "${var.environment_name}"
   dns_zone_id = "${module.core.dns_zone_id}"
 


### PR DESCRIPTION
### Context

This commit removes registers which are either in the new `discovery` environment (and hence no longer needed here), in addition to those registers which no longer exist in any environment.

### Changes proposed in this pull request

Remove registers no longer required in `registers.tf`.

### Guidance to review

Run `make plan -e vpc=ENVIRONMENT` for each environment to confirm there are no changes necessary (make sure to `make pull-config -e vpc=ENVIRONMENT` for each environment first).
