### PR TITLE
add option to add system entry updating field text

### DIFF
--- a/scripts/system_field_text_update.rb
+++ b/scripts/system_field_text_update.rb
@@ -1,0 +1,2 @@
+rsf = IO.read(ARGV[0])
+File.write(ARGV[0], rsf.gsub!(/\t(user)\t((\w|-)+)/m, "\tsystem\tfield:" + '\2'))

--- a/scripts/system_field_text_update.rb
+++ b/scripts/system_field_text_update.rb
@@ -1,2 +1,2 @@
 rsf = IO.read(ARGV[0])
-File.write(ARGV[0], rsf.gsub!(/\t(user)\t((\w|-)+)/m, "\tsystem\tfield:" + '\2'))
+File.write(ARGV[0], rsf.gsub!(/\tuser\t([\w-]+)/m, "\tsystem\tfield:" + '\1'))

--- a/scripts/update-metadata-yaml.sh
+++ b/scripts/update-metadata-yaml.sh
@@ -9,7 +9,7 @@ source "$OPENREGISTER_BASE/deployment/scripts/includes/register-actions.sh"
 
 usage()
 {
-  echo "usage: ./update-metadata-yaml.sh [register|field|datatype] [phase] [yaml file relative to root] [local|remote]" 
+  echo "usage: ./update-metadata-yaml.sh [register|field|datatype] [phase] [yaml file relative to root] [local|remote] [non-basic register]" 
 }
 
 # validation check number of args but other validation is done in python script
@@ -23,6 +23,7 @@ REGISTER=$1
 PHASE=$2
 YAML="$OPENREGISTER_BASE/$3"
 METADATA_SOURCE=$4
+NON_BASIC_REGISTER=$5
 
 update_registers_pass
 
@@ -36,8 +37,13 @@ else
   python3 $OPENREGISTER_BASE/deployment/scripts/rsfcreator.py $REGISTER $PHASE --yaml $YAML --include_user_data > $OPENREGISTER_BASE/tmp.rsf
 fi
 
-PASSWORD=`PASSWORD_STORE_DIR=~/.registers-pass pass $PHASE/app/mint/$REGISTER`
-
-load_rsf $REGISTER $PHASE $PASSWORD
+if [ -n "$NON_BASIC_REGISTER" ]; then
+  ruby system_field_text_update.rb $OPENREGISTER_BASE/tmp.rsf
+  PASSWORD=`PASSWORD_STORE_DIR=~/.registers-pass pass $PHASE/app/mint/$NON_BASIC_REGISTER`
+  load_rsf $NON_BASIC_REGISTER $PHASE $PASSWORD
+else
+  PASSWORD=`PASSWORD_STORE_DIR=~/.registers-pass pass $PHASE/app/mint/$REGISTER`
+  load_rsf $REGISTER $PHASE $PASSWORD
+fi
 
 rm $OPENREGISTER_BASE/tmp.rsf


### PR DESCRIPTION
### Context
Previously we did not have a programatic way to generate field text updates. i.e. those enabled by https://github.com/openregister/openregister-java/pull/332

### Changes proposed in this pull request
Add option to `update-metadata-yaml.sh` to write field updates to non-basic register
Note: I wrote the script in Ruby because I found it easiest but if people feel strongly against this they are welcome to help me port it to another language 😉 

### Guidance to review
A usage example is:
`./update-metadata-yaml.sh field test registry-data/data/beta/field/start-date.yaml local country`
which would update `start-date` in the `country` register.

