### PR TITLE
Add name-a-register script

### DIFF
--- a/scripts/name-a-register.sh
+++ b/scripts/name-a-register.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -e
+
+usage()
+{
+  echo -e "usage: ./name-a-register.sh phase register description\ne.g. ./name-a-register.sh alpha country \"Countries recognised by the UK\""
+}
+
+# validation check number of args but other validation is done in python script
+if [ $# -lt 5 ]; then
+  echo "error: not enough arguments"
+  usage
+  exit 1
+fi
+
+PHASE=$1
+REGISTER=$2
+DESCRIPTION=$3
+echo "PHASE - $PHASE"
+echo "REGISTER - $REGISTER"
+echo "DESCRIPTION - $DESCRIPTION"
+
+OPENREGISTER_BASE="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
+echo "OPENREGISTER_BASE - $OPENREGISTER_BASE"
+source "$OPENREGISTER_BASE/deployment/scripts/includes/register-actions.sh"
+
+URL=$(get_register_url $register $phase)
+echo "URL - $URL"
+
+TIME=`date +%Y-%m-%dT%H:%M:%SZ`
+JSON="{\"register-name\":\"$DESCRIPTION\"}"
+SHA256=`echo -n $JSON | shasum -a 256 | head -c 64`
+PASSWORD=`PASSWORD_STORE_DIR=~/.registers-pass pass $PHASE/app/mint/$REGISTER`
+
+RSF="add-item\t$JSON\nappend-entry\tsystem\tregister-name\t$TIME\tsha-256:$SHA256"
+echo "RSF - $RSF"
+
+echo -ne "$RSF" > $OPENREGISTER_BASE/tmp.rsf
+
+load_rsf $REGISTER $PHASE $PASSWORD
+
+rm $OPENREGISTER_BASE/tmp.rsf

--- a/scripts/name-a-register.sh
+++ b/scripts/name-a-register.sh
@@ -24,9 +24,6 @@ OPENREGISTER_BASE="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
 echo "OPENREGISTER_BASE - $OPENREGISTER_BASE"
 source "$OPENREGISTER_BASE/deployment/scripts/includes/register-actions.sh"
 
-URL=$(get_register_url $register $phase)
-echo "URL - $URL"
-
 TIME=`date +%Y-%m-%dT%H:%M:%SZ`
 JSON="{\"register-name\":\"$DESCRIPTION\"}"
 SHA256=`echo -n $JSON | shasum -a 256 | head -c 64`

--- a/scripts/name-a-register.sh
+++ b/scripts/name-a-register.sh
@@ -7,7 +7,7 @@ usage()
 }
 
 # validation check number of args but other validation is done in python script
-if [ $# -lt 5 ]; then
+if [ $# -lt 3 ]; then
   echo "error: not enough arguments"
   usage
   exit 1


### PR DESCRIPTION
### Context

Registers can now have titles independently of their unique ID.  This script is
for setting that title.

It might make more sense to incorporate the register title into the yaml
definitions of register metadata, but it was quicker to make this script.

### Changes proposed in this pull request

Add a script `/scripts/name-a-register.sh` for naming a register as follows:

```sh
./name-a-register.sh alpha country "Countries recognised by the UK"
```

### Guidance to review

1. Check out the branch
2. Test the script with, e.g. the `fire-authority` register in the `alpha` environment
3. Download the RSF of the register and check that the `register-name` entry exists