### PR TITLE
Script to generate RSF to change register descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,28 @@ example:
 These last two scripts look for the yaml configuration of the register or field
 in the `registry-data` repository.
 
+## Changing descriptions of an existing register
+
+There is a script in `scripts/update_descriptions.py` to generate RSF to change the description of a register that is currently in beta.
+
+Run this using:
+
+```
+register=jobcentre-district
+old_description='bla bla bla'
+new_description='bla bla bla bla bla bla'
+
+python update_descriptions.py $register $old_description $new_description > ${register}_update.rsf
+```
+
+Then load the RSF using:
+
+```
+./rsf-load.sh "https://${register}.beta.openregister.org" openregister `register-pass beta/app/mint/$register` < ${register}_update.rsf
+```
+
+This will update the API explorer, but registers frontend won't automatically pick up the description at the moment, because system entries are not included in incremental updates.
+
 ## Licence
 
 Unless stated otherwise, the codebase is released under [the MIT licence](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ secrets.  You may want to `chmod 600 terraform.tfvars` for safety too.
 
 ### Set up `registers-pass`
 
-The registers team maintains a [credentials store](https://github.com/openregister/credentials/). 
+The registers team maintains a [credentials store](https://github.com/openregister/credentials/).
 You must be able to decrypt and create passwords using the command `registers-pass`. This command
-is used by some of the adhoc ansible commands required to set up register deployments. Follow 
+is used by some of the adhoc ansible commands required to set up register deployments. Follow
 the [instructions](https://github.com/openregister/credentials/README.md) to set this up.
 
 # Deploying registers infrastructure
@@ -84,7 +84,7 @@ Create a new branch and generate credentials using the `ansible/generate_passwor
     ansible-playbook generate_passwords.yml -e vpc=<myenv>
 
 Check that the new password has been created and committed to the new branch, then push.
-    
+
     registers-pass git log
     registers-pass git push -u origin create-new-register
 
@@ -98,10 +98,10 @@ Merge this to master then ensure your `registers-pass` is using latest master
 The `ansible/upload_configs_to_s3.yml` file creates the application
 config files (`pass-config.yaml`) required for each register in each environment.
 The config files are written locally to `ansible/config/<myenv>` and
-uploaded to S3 buckets. This ansible script consumes credentials via `registers-pass` and adds any 
+uploaded to S3 buckets. This ansible script consumes credentials via `registers-pass` and adds any
 new registers to the list of registers to be run by the application. When the application runs
 it will pull the relevant `paas-config.yaml` file from S3.
-If you want to test this script and not upload to S3 you can set `sync: false` in `upload_configs_to_s3.yml`. 
+If you want to test this script and not upload to S3 you can set `sync: false` in `upload_configs_to_s3.yml`.
 
     cd ansible
     ansible-playbook upload_configs_to_s3.yml -e vpc=<myenv>
@@ -162,7 +162,7 @@ If you are creating a register in beta, you must follow [these additional steps]
 
 ## How to create a register group in an existing environment
 
-Edit `ansible/group_vars/tag_Environment_<myenv>` and add the new group to `register_groups`, 
+Edit `ansible/group_vars/tag_Environment_<myenv>` and add the new group to `register_groups`,
 including the register names that are part of this group.
 
 Follow steps 2-3 above.
@@ -181,8 +181,8 @@ Create a new `.tfvars` file for the environment:
 
     ansible-playbook configure_terraform.yml -e vpc=<myenv>
 
-You must also request a new SSL certificate in AWS Certficate Manager for the new environment. 
-This certificate will require approval before it can be used. Bear in mind that only certain people 
+You must also request a new SSL certificate in AWS Certficate Manager for the new environment.
+This certificate will require approval before it can be used. Bear in mind that only certain people
 can approve the creation of new certificates when creating a new environment.
 
 Once approved, the ARN for the new certificate must then be added to the existing terraform configuration file as below.
@@ -212,7 +212,7 @@ Upload the new certificate to IAM using terraform. Follow the instructions [here
 
 ### Rotate SSL certificate for CloudFront distributions
 
-Each Beta register has a CloudFront distribution. These will be using the old certificate (without the `<myregister>.register.gov.uk` 
+Each Beta register has a CloudFront distribution. These will be using the old certificate (without the `<myregister>.register.gov.uk`
 alternative domain). You need to update the certificate for each of the CloudFront distributions. Do this by updating `cdn_configuration.certificate_id` in `aws/registers/environments/beta.tfvars`. Then apply the changes using terraform.
 
 	cd aws/registers
@@ -221,14 +221,14 @@ alternative domain). You need to update the certificate for each of the CloudFro
 
 ### Delete the old certificate
 
-Rerun `make apply` at `aws/tls-certs` (as mentioned in the instructions [here](aws/tls-certs/README.md)) 
+Rerun `make apply` at `aws/tls-certs` (as mentioned in the instructions [here](aws/tls-certs/README.md))
 to delete the old certificate from IAM.
 
 ### Rotate SSL certificate for API Gateway
 
 Use the AWS CLI to rotate the SSL certificate.
 
-Get the Certificate ARN by running. 
+Get the Certificate ARN by running.
 `aws acm list-certificates --region us-east-1`
 and copy the ARN for `register.gov.uk`
 
@@ -299,28 +299,6 @@ example:
 
 These last two scripts look for the yaml configuration of the register or field
 in the `registry-data` repository.
-
-## Changing descriptions of an existing register
-
-There is a script in `scripts/update_descriptions.py` to generate RSF to change the description of a register that is currently in beta.
-
-Run this using:
-
-```
-register=jobcentre-district
-old_description='bla bla bla'
-new_description='bla bla bla bla bla bla'
-
-python update_descriptions.py $register $old_description $new_description > ${register}_update.rsf
-```
-
-Then load the RSF using:
-
-```
-./rsf-load.sh "https://${register}.beta.openregister.org" openregister `register-pass beta/app/mint/$register` < ${register}_update.rsf
-```
-
-This will update the API explorer, but registers frontend won't automatically pick up the description at the moment, because system entries are not included in incremental updates.
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ secrets.  You may want to `chmod 600 terraform.tfvars` for safety too.
 
 ### Set up `registers-pass`
 
-The registers team maintains a [credentials store](https://github.com/openregister/credentials/).
+The registers team maintains a [credentials store](https://github.com/openregister/credentials/). 
 You must be able to decrypt and create passwords using the command `registers-pass`. This command
-is used by some of the adhoc ansible commands required to set up register deployments. Follow
+is used by some of the adhoc ansible commands required to set up register deployments. Follow 
 the [instructions](https://github.com/openregister/credentials/README.md) to set this up.
 
 # Deploying registers infrastructure
@@ -84,7 +84,7 @@ Create a new branch and generate credentials using the `ansible/generate_passwor
     ansible-playbook generate_passwords.yml -e vpc=<myenv>
 
 Check that the new password has been created and committed to the new branch, then push.
-
+    
     registers-pass git log
     registers-pass git push -u origin create-new-register
 
@@ -98,10 +98,10 @@ Merge this to master then ensure your `registers-pass` is using latest master
 The `ansible/upload_configs_to_s3.yml` file creates the application
 config files (`pass-config.yaml`) required for each register in each environment.
 The config files are written locally to `ansible/config/<myenv>` and
-uploaded to S3 buckets. This ansible script consumes credentials via `registers-pass` and adds any
+uploaded to S3 buckets. This ansible script consumes credentials via `registers-pass` and adds any 
 new registers to the list of registers to be run by the application. When the application runs
 it will pull the relevant `paas-config.yaml` file from S3.
-If you want to test this script and not upload to S3 you can set `sync: false` in `upload_configs_to_s3.yml`.
+If you want to test this script and not upload to S3 you can set `sync: false` in `upload_configs_to_s3.yml`. 
 
     cd ansible
     ansible-playbook upload_configs_to_s3.yml -e vpc=<myenv>
@@ -162,7 +162,7 @@ If you are creating a register in beta, you must follow [these additional steps]
 
 ## How to create a register group in an existing environment
 
-Edit `ansible/group_vars/tag_Environment_<myenv>` and add the new group to `register_groups`,
+Edit `ansible/group_vars/tag_Environment_<myenv>` and add the new group to `register_groups`, 
 including the register names that are part of this group.
 
 Follow steps 2-3 above.
@@ -181,8 +181,8 @@ Create a new `.tfvars` file for the environment:
 
     ansible-playbook configure_terraform.yml -e vpc=<myenv>
 
-You must also request a new SSL certificate in AWS Certficate Manager for the new environment.
-This certificate will require approval before it can be used. Bear in mind that only certain people
+You must also request a new SSL certificate in AWS Certficate Manager for the new environment. 
+This certificate will require approval before it can be used. Bear in mind that only certain people 
 can approve the creation of new certificates when creating a new environment.
 
 Once approved, the ARN for the new certificate must then be added to the existing terraform configuration file as below.
@@ -212,7 +212,7 @@ Upload the new certificate to IAM using terraform. Follow the instructions [here
 
 ### Rotate SSL certificate for CloudFront distributions
 
-Each Beta register has a CloudFront distribution. These will be using the old certificate (without the `<myregister>.register.gov.uk`
+Each Beta register has a CloudFront distribution. These will be using the old certificate (without the `<myregister>.register.gov.uk` 
 alternative domain). You need to update the certificate for each of the CloudFront distributions. Do this by updating `cdn_configuration.certificate_id` in `aws/registers/environments/beta.tfvars`. Then apply the changes using terraform.
 
 	cd aws/registers
@@ -221,14 +221,14 @@ alternative domain). You need to update the certificate for each of the CloudFro
 
 ### Delete the old certificate
 
-Rerun `make apply` at `aws/tls-certs` (as mentioned in the instructions [here](aws/tls-certs/README.md))
+Rerun `make apply` at `aws/tls-certs` (as mentioned in the instructions [here](aws/tls-certs/README.md)) 
 to delete the old certificate from IAM.
 
 ### Rotate SSL certificate for API Gateway
 
 Use the AWS CLI to rotate the SSL certificate.
 
-Get the Certificate ARN by running.
+Get the Certificate ARN by running. 
 `aws acm list-certificates --region us-east-1`
 and copy the ARN for `register.gov.uk`
 

--- a/scripts/readme.md
+++ b/scripts/readme.md
@@ -102,6 +102,27 @@ with the `scripts/name-a-register.sh` script.
 ./name-a-register.sh alpha country "A list of countries recognised by the UK"
 ```
 
+### Changing the description of a register
+
+There is a script in `scripts/update_descriptions.py` to generate RSF to change the description of a register. This currently assumes that the register is in beta.
+
+Run this using:
+
+```
+register=jobcentre-district
+new_description='bla bla bla bla bla bla'
+
+python update_descriptions.py $register $new_description > ${register}_update.rsf
+```
+
+Then load the RSF using:
+
+```
+./rsf-load.sh "https://${register}.beta.openregister.org" openregister `register-pass beta/app/mint/$register` < ${register}_update.rsf
+```
+
+This will update the API explorer, but at the time of writing, registers frontend won't automatically pick up the description, because system entries are not included in incremental updates.
+
 ### Python tests
 
 There are some unit tests for the python script and some test data. To run them:

--- a/scripts/readme.md
+++ b/scripts/readme.md
@@ -104,7 +104,7 @@ with the `scripts/name-a-register.sh` script.
 
 ### Changing the description of a register
 
-There is a script in `scripts/update_descriptions.py` to generate RSF to change the description of a register. This currently assumes that the register is in beta.
+There is a script in `scripts/update_descriptions.py` to generate RSF to change the description of a register.
 
 Run this using:
 
@@ -120,6 +120,8 @@ Then load the RSF using:
 ```
 ./rsf-load.sh "https://${register}.beta.openregister.org" openregister `register-pass beta/app/mint/$register` < ${register}_update.rsf
 ```
+
+This example assumes that the register is in beta.
 
 This will update the API explorer, but at the time of writing, registers frontend won't automatically pick up the description, because system entries are not included in incremental updates.
 

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,3 +1,4 @@
 pyyaml
 requests
+hypothesis
 

--- a/scripts/update_descriptions.py
+++ b/scripts/update_descriptions.py
@@ -1,0 +1,47 @@
+import requests
+import sys
+import hashlib
+import re
+import json
+import datetime
+
+def sha256(value):
+    m = hashlib.sha256()
+    m.update(value)
+    return m.hexdigest()
+
+if __name__ == '__main__':
+    if len(sys.argv) != 4:
+        print('Usage: ... <register> <old_description> <new_description>', file=sys.stderr)
+        sys.exit(1)
+    register = sys.argv[1]
+    old_desc = sys.argv[2]
+    new_desc = sys.argv[3]
+    print(f'<{register}> change "{old_desc}" -> "{new_desc}"', file=sys.stderr)
+
+    response = requests.get(f'https://{register}.beta.openregister.org/download-rsf')
+
+    old_item = None
+    old_hash = None
+    old_add_entry = None
+    for line in response.iter_lines():
+        match = re.match(rf'^add-item\t(.*{old_desc}.*)'.encode('utf8'), line)
+        if match:
+            old_item = match.group(1)
+
+            old_hash = sha256(old_item)
+            old_item = json.loads(old_item)
+
+    if not old_item:
+        print('Failed to find the old item', file=sys.stderr)
+        sys.exit(1)
+
+    new_item = old_item.copy()
+    new_item['text'] = new_desc
+    new_item = json.dumps(new_item, separators=(',', ':'))
+    new_hash = sha256(new_item.encode('utf8'))
+    print(f'add-item\t{new_item}')
+
+    # example: '2018-02-01T13:30:23Z'
+    timestamp = datetime.datetime.utcnow().isoformat(timespec='seconds')
+    print(f'append-entry\tsystem\tregister:{register}\t{timestamp}Z\tsha-256:{new_hash}')

--- a/scripts/update_descriptions.py
+++ b/scripts/update_descriptions.py
@@ -7,7 +7,7 @@ import datetime
 from enum import Enum
 
 
-ITEM_REGEX = re.compile(r'^add-item\t({[^}]+})$')
+ITEM_REGEX = re.compile(r'^add-item\t({[^\t]*})$')
 ENTRY_REGEX = re.compile(r'^append-entry\t([^\t]+)\t([^\t]+)\t([^\t]+)\t([^\t]+)$')
 
 
@@ -80,13 +80,13 @@ class RsfAppendEntry:
         self.entry_type = entry_type
 
         # example: '2018-02-01T13:30:23Z'
-        self.timestamp = timestamp or datetime.datetime.utcnow().isoformat(timespec='seconds')
+        self.timestamp = timestamp or datetime.datetime.utcnow().isoformat(timespec='seconds') + 'Z'
         self.key = key
         self.item_hash = item_hash
         self.command = RsfCommand.APPEND_ENTRY
 
     def __str__(self):
-        return f'append-entry\t{self.entry_type}\t{self.key}\t{self.timestamp}Z\t{self.item_hash}'
+        return f'append-entry\t{self.entry_type}\t{self.key}\t{self.timestamp}\t{self.item_hash}'
 
 
 if __name__ == '__main__':

--- a/scripts/update_descriptions_test.py
+++ b/scripts/update_descriptions_test.py
@@ -1,0 +1,63 @@
+import unittest
+from hypothesis import given, example, reproduce_failure, assume
+from hypothesis.strategies import text, recursive, booleans, floats, none, lists, dictionaries, datetimes, one_of, just
+from string import printable
+from update_descriptions import RsfAddItem, RsfAppendEntry, parse_rsf_line, find_register_item
+
+json_values = none() | booleans() | floats() | text(printable)
+json_values = json_values | lists(json_values)
+flat_json = dictionaries(text(printable), json_values)
+not_tabs = printable.replace('\t', '')
+
+class TestRsf(unittest.TestCase):
+    @given(flat_json)
+    @example({"fields":["country","name","official-name","citizen-names","start-date","end-date"],"phase":"beta","register":"country","registry":"foreign-commonwealth-office","text":"British English-language names and descriptive terms for countries"})
+    def test_serialising_and_parsing_items_is_consistent(self, item):
+        add_item = RsfAddItem(item)
+        rsf = str(add_item)
+        parsed = parse_rsf_line(rsf)
+        rsf2 = str(parsed)
+
+        self.assertEquals(rsf, rsf2)
+
+    @given(text(not_tabs, min_size=1), text(not_tabs, min_size=1), datetimes(), one_of(just('system'), just('user'), text(not_tabs, min_size=1)))
+    def test_serialising_and_parsing_entries_is_consistent(self, key, item_hash, timestamp, entry_type):
+        timestamp = timestamp.isoformat(timespec='seconds') + 'Z'
+        entry = RsfAppendEntry(key, item_hash, timestamp, entry_type)
+        rsf = str(entry)
+        parsed = parse_rsf_line(rsf)
+        rsf2 = str(parsed)
+
+        self.assertEquals(rsf, rsf2)
+
+    def test_invalid_rsf_does_not_parse(self):
+        self.assertIsNone(parse_rsf_line(''))
+        self.assertIsNone(parse_rsf_line('hello'))
+        self.assertIsNone(parse_rsf_line('\t'))
+
+    def test_register_items_are_findable(self):
+        rsf = [
+            b'add-item	{"fields":["jobcentre-district","name","jobcentre-group","start-date","end-date"],"phase":"beta","register":"jobcentre-district","registry":"department-for-work-pensions","text":"Districts of jobcentre offices in England, Scotland and Wales"}',
+            b'append-entry	system	register:jobcentre-district	2018-07-13T09:38:47Z	sha-256:8b2905acc66d55b330213e03b61316dbd74ec3f012722237e0cd3327276d999e',
+        ]
+        item = find_register_item('jobcentre-district', rsf)
+        self.assertEquals(item.item_hash(), 'sha-256:8b2905acc66d55b330213e03b61316dbd74ec3f012722237e0cd3327276d999e')
+
+    def test_item_lookup_is_by_most_recent_entry(self):
+        rsf = [
+            b'add-item	{"fields":["jobcentre-district","name","jobcentre-group","start-date","end-date"],"phase":"beta","register":"jobcentre-district","registry":"department-for-work-pensions","text":"Districts of jobcentre offices in England, Scotland and Wales"}',
+            b'append-entry	system	register:jobcentre-district	2018-07-13T09:38:47Z	sha-256:8b2905acc66d55b330213e03b61316dbd74ec3f012722237e0cd3327276d999e',
+            b'add-item	{"fields":["jobcentre-district","name","jobcentre-group","start-date","end-date"],"phase":"beta","register":"jobcentre-district","registry":"department-for-work-pensions","text":"Updated"}',
+            b'append-entry	system	register:jobcentre-district	2018-07-13T09:38:47Z	sha-256:f14292b0d801b81ebf625906c996ff3493b71b0e9fbad551e814b10129ab2218',
+            b'add-item	{"fields":["jobcentre-district","name","jobcentre-group","start-date","end-date"],"phase":"beta","register":"jobcentre-district","registry":"department-for-work-pensions","text":"No entry"}',
+        ]
+        item = find_register_item('jobcentre-district', rsf)
+        self.assertEquals(item.item_hash(), 'sha-256:f14292b0d801b81ebf625906c996ff3493b71b0e9fbad551e814b10129ab2218')
+
+    def test_other_keys_are_ignored_in_item_lookup(self):
+        rsf = [
+            b'add-item	{"fields":["jobcentre-district","name","jobcentre-group","start-date","end-date"],"phase":"beta","register":"jobcentre-district","registry":"department-for-work-pensions","text":"Districts of jobcentre offices in England, Scotland and Wales"}',
+            b'append-entry	system	something-else	2018-07-13T09:38:47Z	sha-256:8b2905acc66d55b330213e03b61316dbd74ec3f012722237e0cd3327276d999e',
+        ]
+        item = find_register_item('jobcentre-district', rsf)
+        self.assertIsNone(item)


### PR DESCRIPTION
### Context
For https://trello.com/c/yljdvr9J/2635-bau-update-register-descriptions-for-beta-registers we had to update descriptions for a bunch of registers.

This isn't yet in the managing registers tool, so we have to manually create `add-item` and `append-entry` RSF to add a system entry to the register.

### Changes proposed in this pull request
This was tedious and a bit error prone so I scripted the RSF generation part.

I'd be happy to make this more general purpose at a later date but for now I've just implemented what I needed to get the job done.

### Guidance to review
