### PR TITLE
Use ACM instead of IAM for register.gov.uk SSL certificates

### DIFF
--- a/aws/modules/register/cdn.tf
+++ b/aws/modules/register/cdn.tf
@@ -11,7 +11,7 @@ resource "aws_cloudfront_distribution" "distribution" {
   price_class = "PriceClass_100"
 
   viewer_certificate {
-    iam_certificate_id = "${var.cdn_configuration["certificate_id"]}"
+    acm_certificate_arn = "${var.cdn_configuration["certificate_arn"]}"
     ssl_support_method = "sni-only"
     minimum_protocol_version = "TLSv1"
   }


### PR DESCRIPTION
### Context
We currently use IAM to store SSL certificates that we manually create via LetsEncrypt for the *.register.gov.uk domain. It's now possible to use AWS Certificate Manager to create these certificates using DNS validation, which has perks such as automatic renewal (as long as the DNS records still exist). It will mean that we no longer need to use LetsEncrypt for beta registers 🎉 

### Changes proposed in this pull request
Use `acm_certificate_arn` instead of `iam_certificate_id` to set SSL certificate for *.register.gov.uk CloudFront distributions.

Once we're happy that this is all working there will be a separate clean-up PR to remove all the LetsEncrypt code.

### Guidance to review
If you want to do a `terraform plan` you can do so against beta but will need to remove the `cdn_configuration.certifcate_id` variable to be `cdn_configuration.certifcate_arn` and use an appropriate ARN from ACM. I will apply this change once the PR is approved.