### PR TITLE
Skip meta.yaml in validate script

### DIFF
--- a/scripts/validate_metadata.py
+++ b/scripts/validate_metadata.py
@@ -60,6 +60,9 @@ if __name__ == '__main__':
 
     for item in registers.json():
         name = item['name'].replace('.yaml', '')
+        if name == 'meta':
+            continue
+
         path = item['path']
         result = Result(name)
 


### PR DESCRIPTION
### Context
This script compares register data to YAML files in github.

Since I added a meta.yaml to registry-data/data/beta/registers, this script breaks half way through because it assumes all yaml defines a register.

### Changes proposed in this pull request
Skip over that meta.yaml.

### Guidance to review
