### PR TITLE
set allow_overwrite to false for additional record

### DIFF
--- a/aws/modules/register/dns.tf
+++ b/aws/modules/register/dns.tf
@@ -1,4 +1,5 @@
 resource "aws_route53_record" "record" {
+  allow_overwrite = "false"
   count = "${var.enabled ? 1 : 0}"
 
   name = "${var.name}"


### PR DESCRIPTION
### Context
Update following #535

### Changes proposed in this pull request
Set `allow_override = false` in one more location

### Guidance to review
`make plan -e vpc=alpha` should show `allow_override = false` on all register records.
