### PR TITLE
more inclusive wildcard invalidation

### DIFF
--- a/aws/lambda/node/cache-invalidator/lambda.js
+++ b/aws/lambda/node/cache-invalidator/lambda.js
@@ -48,18 +48,16 @@ exports.handler = async event => {
 		InvalidationBatch: { /* Required */
 			CallerReference: callerReference, /* Required */
 			Paths: { /* Required */
-				Quantity: 11, /* Required */
+				Quantity: 9, /* Required */
 				Items: [
 					'/download-register',
 					'/',
 					'/records',
+					'/records*',
 					'/register*',
-					'/records?*',
-					'/records/*',
 					'/entries',
+					'/entries*',
 					'/download-rsf*',
-					'/entries/?*',
-					'/entries?*',
 					'/proof/register/merkle:sha-256'
 				]
 			}


### PR DESCRIPTION
### Context
The previous paths did not cover some routes e.g. `/records.csv`

### Changes proposed in this pull request
Broaden wildcard

### Guidance to review
`sam local invoke "CacheInvalidatorFunction" --event ./cache-invalidator/example_event.json` should successfully trigger invalidation.
