### PR TITLE
Check the right variable name when adding user agent to GA payload

### DIFF
--- a/aws/lambda/node/cloudfront-logs-api-key-to-google-analytics/lambda.js
+++ b/aws/lambda/node/cloudfront-logs-api-key-to-google-analytics/lambda.js
@@ -41,7 +41,7 @@ exports.handler = function (input, context, callback) {
 					cd5: requestData.hittype
 				}
 
-				if (requestData.userAgent !== undefined) {
+				if (requestData.useragent !== undefined) {
 					queryParams.cd6 = requestData.useragent.substring(0,150); // Max length: 150 bytes
 					queryParams.ua = requestData.useragent;
 				}


### PR DESCRIPTION
### Context
This lambda sends hits to GA. We recently add a new custom dimension for user agent, but it's not being sent properly.

### Changes proposed in this pull request
Correct a typo in the undefined check.

I don't know if this is the sole problem, as I still had problems when manually crafting a payload via the hitbuilder tool (https://ga-dev-tools.appspot.com/hit-builder/) but this surely isn't helping.

### Guidance to review
This should match the payload logged by the "log api key to cloudwatch" lambda.