### PR TITLE
create workspace if does not already exist

### DIFF
--- a/aws/registers/Makefile
+++ b/aws/registers/Makefile
@@ -38,7 +38,7 @@ module_depth:=-1
 
 configure-state:
 	terraform init
-	terraform workspace select $(vpc)
+	terraform workspace select $(vpc) || terraform workspace new $(vpc)
 
 pull-config:
 	aws s3 cp s3://registers-terraform-config/$(vpc).tfvars environments/$(vpc).tfvars


### PR DESCRIPTION
### Context
https://trello.com/c/tFPzJu4j/3173-terraform-makefile-should-autogenerate-new-workspace-if-it-does-not-already-exist

### Changes proposed in this pull request
Creates terraform workspace if does not already exist. Fix is that suggested in: https://github.com/hashicorp/terraform/issues/16191#issuecomment-342787924

### Guidance to review
```
cd aws/registers
make configure-state -e vpc=test
```
should run without error for first time user.