### PR TITLE
fix security warnings

### DIFF
--- a/ansible/includes/check_ansible_version.yml
+++ b/ansible/includes/check_ansible_version.yml
@@ -4,7 +4,7 @@
   connection: local
   gather_facts: no
   vars:
-    expected_version: '2.2.1.0'
+    expected_version: '2.3.1.0'
   tasks:
     - assert:
         that:

--- a/ansible/requirements.txt
+++ b/ansible/requirements.txt
@@ -1,4 +1,4 @@
-ansible==2.2.1.0
+ansible==2.3.1.0
 boto==2.45.0
 cffi==1.9.1
 cryptography==1.7.1
@@ -11,6 +11,5 @@ netaddr==0.7.19
 paramiko>=2.1.6
 pyasn1==0.1.9
 pycparser==2.17
-pycrypto==2.6.1
-PyYAML==3.12
+PyYAML==4.2b2 # Using beta version as no non-beta version contains security fix
 six==1.10.0


### PR DESCRIPTION
### Context
fix github security warnings

### Changes proposed in this pull request
update versions

there is no patched version available for `pycrypto`, I cannot find any usage of this dependency so I am removing it and suggest we revert if anything breaks.

### Guidance to review
Github warning should go away after merge