### PR TITLE
perform terraform workspace list before select

### DIFF
--- a/aws/registers/Makefile
+++ b/aws/registers/Makefile
@@ -38,7 +38,7 @@ module_depth:=-1
 
 configure-state:
 	terraform init
-	terraform workspace select $(vpc) || terraform workspace new $(vpc)
+	terraform workspace list && terraform workspace select $(vpc)
 
 pull-config:
 	aws s3 cp s3://registers-terraform-config/$(vpc).tfvars environments/$(vpc).tfvars


### PR DESCRIPTION
### Context
Attempting fix for issue encountered during register loading process

### Changes proposed in this pull request

From a clean install the previous command caused a new empty workspace to be created which meant terraform would attempt to create all resources. After some trial and error it appears that running `terraform workspace list` prompts terraform to find available remote workspaces in S3 which can then be switched to safely.

### Guidance to review
run `make plan -e vpc=test`
Terraform should show `No changes. Infrastructure is up-to-date.`