### PR TITLE
init lambda terraform prior to make plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ appropriate `register` module resource in `registers.tf` (if it does not already
 You should expect terrafrom to plan to create a new Route 53 DNS record. For non-discovery registers it should also plan to create a new Pingdom availability check.
 
         cd aws/registers
-        make plan -e vpc=<myenv>
+        (cd ../lambda/; terraform init) && make plan -e vpc=<myenv>
 
 ### 8. Apply terraform changes
 


### PR DESCRIPTION
### Context
Issue discovered during register loading process

### Changes proposed in this pull request
We have an inter-dependency between the registers & lambda terraforms. From a clean install if lambda terraform has not been init'd the registers terraform will show errors as it cannot derive a required attribute

### Guidance to review
command in readme should run without error