### PR TITLE
remove separate alpha approval step

### DIFF
--- a/aws/pipeline/openregister-java_pipeline.tf
+++ b/aws/pipeline/openregister-java_pipeline.tf
@@ -158,10 +158,10 @@ resource "aws_codepipeline" "pipeline" {
   }
 
   stage {
-    name = "AlphaApproval"
+    name = "AlphaAndBetaApproval"
 
     action {
-      name = "DeployToAlphaProduction"
+      name = "DeployToAlphaAndBetaProduction"
       category = "Approval"
       owner = "AWS"
       provider = "Manual"
@@ -170,7 +170,7 @@ resource "aws_codepipeline" "pipeline" {
   }
 
   stage {
-    name = "DeployToAlpha"
+    name = "DeployToAlphaAndBetaProduction"
 
     action {
       name = "deploy-alpha-basic"
@@ -199,22 +199,6 @@ resource "aws_codepipeline" "pipeline" {
         ProjectName = "${module.alpha_multi.name}"
       }
     }
-  }
-
-  stage {
-    name = "BetaApproval"
-
-    action {
-      name = "DeployToBeta"
-      category = "Approval"
-      owner = "AWS"
-      provider = "Manual"
-      version = "1"
-    }
-  }
-
-  stage {
-    name = "DeployToBeta"
 
     action {
       name = "deploy-beta-basic"


### PR DESCRIPTION
### Context
Simplify deployment

### Changes proposed in this pull request
Currently we have automatic deployment following merge to Test and Discovery environments followed by 2 manual approval steps to deploy ORJ `AlphaApproval` and `BetaApproval`.
This PR removes 1 of the manual approval steps so that only one approval is required for deployment to both Alpha and Beta.

Rationale is that Alpha and Beta are both effectively 'production' environments with Alpha being rarely used currently and any sanity testing should be performed in the Test environment.

### Guidance to review
Check terraform changes reflect description in PR