### PR TITLE
bump node runtime

### DIFF
--- a/aws/lambda/README.md
+++ b/aws/lambda/README.md
@@ -55,7 +55,7 @@ sam local invoke CloudfrontLogAPIKeyFunction -e log-api-key-to-cloudwatch/exampl
 
 Send API key to Google Analytics:
 ```
-sam local invoke StoreAPIUsageFunction -e cloudfront-logs-api-key-to-google-analytics/examples/logs-no-key.json
+sam local invoke CloudfrontLogsApiKeyToGoogleAnalyticsFunction -e cloudfront-logs-api-key-to-google-analytics/examples/logs-no-key.json
 ```
 
 ### Python lambdas

--- a/aws/lambda/lambda-edge-lambdas.tf
+++ b/aws/lambda/lambda-edge-lambdas.tf
@@ -78,7 +78,7 @@ resource "aws_lambda_function" "api-key-to-cloudfront-logs" {
   handler          = "lambda.handler"
   role             = "${aws_iam_role.lambda-edge-role.arn}"
   memory_size      = "128"
-  runtime          = "nodejs6.10"
+  runtime          = "nodejs8.10"
   timeout          = "5"
   provider         = "aws.us-east-1"
   publish          = true

--- a/aws/lambda/node/cloudfront-logs-api-key-to-google-analytics/module.tf
+++ b/aws/lambda/node/cloudfront-logs-api-key-to-google-analytics/module.tf
@@ -26,7 +26,7 @@ resource "aws_lambda_function" "cloudfront-logs-api-key-to-google-analytics" {
   handler          = "lambda.handler"
   role             = "${data.aws_iam_role.cloudwatch_logs_lambda_role.arn}"
   memory_size      = "128"
-  runtime          = "nodejs6.10"
+  runtime          = "nodejs8.10"
   timeout          = "5"
   provider         = "aws.${var.region}"
 

--- a/aws/lambda/node/template.yml
+++ b/aws/lambda/node/template.yml
@@ -32,14 +32,14 @@ Resources:
         Properties:
             CodeUri: log-api-key-to-cloudwatch/
             Handler: lambda.handler
-            Runtime: nodejs6.10
+            Runtime: nodejs8.10
 
-    StoreAPIUsageFunction:
+    CloudfrontLogsApiKeyToGoogleAnalyticsFunction:
         Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
         Properties:
             CodeUri: cloudfront-logs-api-key-to-google-analytics/
             Handler: lambda.handler
-            Runtime: nodejs6.10
+            Runtime: nodejs8.10
             Environment:
                 Variables:
                     TID: UA-86101042-1


### PR DESCRIPTION
### Context
Node 6.10 is being deprecated

### Changes proposed in this pull request
Bump Lambdas to Node 8.10

### Guidance to review
I have tested the functions still work with this runtime using `sam local`.