### PR TITLE
Add Cyber Security Watch module

### DIFF
--- a/aws/account/README.md
+++ b/aws/account/README.md
@@ -1,0 +1,27 @@
+# Account Wide Terraform
+
+## Requirements
+
+- gds-cli
+- awscli
+- terraform
+
+## How to apply
+
+Navigate in your terminal to this directory:
+
+```
+cd aws/account
+```
+
+Initialise terraform:
+
+```
+gds aws registers -- terraform init
+```
+
+Apply terraform:
+
+```
+gds aws registers -- terraform apply
+```

--- a/aws/account/backend.tf
+++ b/aws/account/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = "~> 0.11.8"
+  backend "s3" {
+    bucket = "registers-terraform-state"
+    key = "account-wide.tfstate"
+    region = "eu-west-1"
+    encrypt = "true"
+  }
+}

--- a/aws/account/csw.tf
+++ b/aws/account/csw.tf
@@ -1,0 +1,5 @@
+module "cyber-security-audit-role" {
+  source = "git::https://github.com/alphagov/tech-ops//cyber-security/modules/gds_security_audit_role?ref=13f54e554b8f56f34f975447a1011a03321c92b6"
+
+  chain_account_id = "988997429095"
+}


### PR DESCRIPTION
### Context

Cyber Security is running checks on all of the AWS accounts and the
Register account is one of the missing in their books.

### Changes proposed in this pull request

Adding the Role which can be assumed from the Cyber Security account,
with View permissions to some resources.

See the module for more details.

### Guidance to review

- See if it has applied